### PR TITLE
Modifications after LinuxCon Meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,77 @@
-# TODO Group Charter v1.0 [DRAFT]
+**Mission statement**
 
-## Mission statement
-To build and share best practices, tools, and other ways to run successful and effective open source programs and projects.
+For open source program office managers, TODO Group is a peer group network that builds and shares best practices, tools, and other guidance you can only build from practical experience for companies looking to successfully engage in or create open source projects and build effective internal open source programs.
 
-## Membership
-The TODO Group shall be composed of a Steering Committee and Community Members.
+**Membership**
 
-There will be at most nine Steering Committee members which are comprised of elected Community Members.
-
-The Steering Committee shall be entitled to:
-* Vote on decisions or matters before the TODO Group
-* Approve a budget directing the use of funds raised from all sources of revenue.
-* Elect a Chair of the TODO Group to preside over meetings and lead operations.
+The TODO Group shall be composed of the Community Members and a Steering Committee.
 
 Community Members shall be entitled to:
-* Participate in TODO Group meetings, initiatives, events and any other activities.
-* Identify their company as a participant in the TODO Group.
 
-All Community Members in good standing are defined as members that have a current Linux Foundation Individual or Corporate Membership.
+* Participate in TODO Group Working Groups, meetings, initiatives, events and any other activities.
 
-## Community Participation
-Developers and representatives of other types of stakeholders may be appointed by a vote of the Steering Committee or for the initial year only, The Linux Foundation. Community Participants do not vote, but are able to participate in all Workgroup activities. Appointments shall last indefinitely, unless revoked by the Steering Committee or The Linux Foundation.
+* Identify their company as a member or participant in the TODO Group.
 
-## Voting
-Actions of the Steering Committee may be taken at in-person meetings, via conference call, or through electronic means, including email or IRC. In order for any action to be effective, it shall be approved by a simple majority of the Steering Committee members participating in person, by electronic means and/or by conference call, when a quorum is so present.
+The Steering Committee shall be entitled to:
 
-## Elections
+* Vote on decisions or matters before the TODO Group
 
-The Steering Committee shall elect a Chairperson, and if so desired, may elect such other officers as it may choose. All officers shall be elected annually, and may be reelected one or more times.
+* Elect a Chair of the TODO Group to preside over meetings and lead operations.
 
-## Deliverables
-The TODO Group commits to producing the following deliverables within the next two years
-* Well documented software to facilitate the management of outgoing open source software within an organization
-* Articles providing recommendations on how to manage outgoing open source software within an organization
+* Approve a budget directing the LF how to expend the funds raised from all sources of revenue.
 
-## Operating Principles
+* Approve, organize and terminate Working Groups.
 
-### Meeting mechanisms and expected frequency
-* Meetings will take place via VOIP or face to face. Face to face meeting may not all take place in the same location.
-* Meetings will occur no less frequently than quarterly
-* Details of meeting mechanisms and instructions for attendance will be published reasonably in advance to all members of good standing
+**Steering Committee**
 
-### Communication mechanisms
-* All public communication not during meetings will take place over the public group mailing list
-* All private communication not during meetings will take place over the private group mailing list
+In order to be manageable, the Steering Committee will be composed of nine (9) Community Members. The Steering Committee members shall initially be the core founders, [names]. [Elections staggered (e.g. 4 after year 1, 5 after year 2) or all 9 every 2 years?]
 
-### Level of confidentiality
-* All communication during meetings will be under [Chatam House Rules](http://en.wikipedia.org/wiki/Chatham_House_Rule)
-* All communication on the private mailing list will be under Chatam House Rules
+**Officers**
+
+The Steering Committee shall elect a Chairperson, and if so desired, may elect such other officers as it may choose. All officers shall be elected annually. There are no limits on the number of terms an officer may serve.
+
+**Voting**
+
+Actions of the Steering Committee may be taken at in-person meetings, via conference call, or through electronic means, including email or IRC. In order for any action to be effective, it shall be approved by a simple majority of the Steering Committee members participating in person and/or by conference call, when a quorum is so present. Quorum shall be met when two-thirds of the Steering Committee members are present. Any vote may be taken without a meeting electronically but shall require a majority of the entire Steering Committee to pass. 
+
+**Working Groups**
+
+The TODO Group will host Working Groups for members to contribute to that are intended to accelerate its mission. Initial Working Groups are expected to cover:
+
+Well documented software to facilitate the management of outgoing open source software within an organization
+
+Blog and wiki articles providing recommendations on how to manage outgoing open source software within an organization
+
+**Operating Principles**
+
+**Meeting mechanisms and expected frequency**
+
+* Meetings will take place via electronic means or face-to-face. Face-to-face meeting locations and times will be set by the Steering Committee.
+
+* Meetings will occur at least once per quarter
+
+* Details of meeting mechanisms and instructions for attendance will be published reasonably in advance to all members in good standing
+
+**Communication mechanisms**
+
+* All public communication not during meetings will take place over the public group mailing list(s) accessible to members and non-members alike.
+
+* All private communication not during meetings will take place over the private group mailing list for members only.
+
+**Level of confidentiality**
+
+* All communication during meetings will be under[ Chatham House Rules](http://en.wikipedia.org/wiki/chatham_house_rule)
+
+* All communication on the private mailing list will be restricted to members only and not permitted for public distribution.
+
 * All communication on the public mailing list will be public
 
-## Antitrust Guidelines
-All members shall abide by The Linux Foundation Antitrust Policy available at: http://www.linuxfoundation.org/antitrust-policy
+**Antitrust Guidelines**
 
-All members shall encourage open participation from any organization able to meet the membership requirements, regardless of competitive interests. Put another way, the TODOGroup shall not seek to exclude members based on any criteria, requirements or reasons other than those used for all members.
+All members shall abide by The Linux Foundation Antitrust Policy available at:[ http://www.linuxfoundation.org/antitrust-policy](http://www.linuxfoundation.org/antitrust-policy)
 
-## Charter Amendment
-This Charter may be amended, and additional rules may be adopted, at any time by a two-thirds majority of all then serving Steering Committee members.
+All members shall encourage open participation from any organization able to meet the membership requirements, regardless of competitive interests. Put another way, the TODO Group shall not seek to exclude members based on any criteria, requirements or reasons other than those used for all members.
+
+**Charter Amendment**
+
+This Charter may be amended, and additional rules may be adopted, at any time by a two-thirds majority of all then serving Steering Committee members with final approval from The Linux Foundation.


### PR DESCRIPTION
At LinuxCon., Henri Yandell, Mark Atwood, Chris Kelly and I met with Mike Dolan from the Linux Foundation to discuss finalizing the charter. A few things were discussed:
- make a steering committee filled with 9 initial members as the voting body
  - all members must be LF members in good standing
- launch and announce our plans at LinuxCon EU on Oct 5th
  - press release work done by the LF
- LF to file and own the trademark for the TODO Group
- have an official TODO event co-located at the CollabSummit in March 2016
  - http://events.linuxfoundation.org/events/collaboration-summit
- potentially do a TODO Group smaller meeting in the bay area before the end of this year

It would be great to get feedback from everyone on the charter, including any modifications so we can do a vote and ask for the first nine volunteers to be on the steering committee :)
