### PR TITLE
Add a basic issue template for SC membership changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/sc-change.md
+++ b/.github/ISSUE_TEMPLATE/sc-change.md
@@ -1,0 +1,21 @@
+---
+name: 'Steering Committee change'
+about: 'Change in Steering Committee membership'
+labels: sc-change
+---
+
+## Who/what?
+
+<!-- Who has joined or left the steering committee? -->
+
+## Information to gather or verify
+
+- [ ] GitHub ID of any new steering committee member(s)
+- [ ] Email address of any new steering committee member(s)
+
+## Things to update
+
+- [ ] [README](https://github.com/todogroup/governance/blob/master/README.md) on the governance repo
+- [ ] `collaborators` array in [settings.yml](https://github.com/todogroup/governance/blob/master/.github/settings.yml)
+- [ ] [steering-committee team](https://github.com/orgs/todogroup/teams/steering-committee) on the TODO Group GitHub organization
+- [ ] Update the Steering Committee email alias on GSuite (LF staff will need to do this one)

--- a/.github/ISSUE_TEMPLATE/sc-change.md
+++ b/.github/ISSUE_TEMPLATE/sc-change.md
@@ -16,6 +16,7 @@ labels: sc-change
 ## Things to update
 
 - [ ] [README](https://github.com/todogroup/governance/blob/master/README.md) on the governance repo
+- [ ] Update the SC member list on the [resolution template](https://github.com/todogroup/governance/blob/master/resolutions/template/standard.md)
 - [ ] `collaborators` array in [settings.yml](https://github.com/todogroup/governance/blob/master/.github/settings.yml)
 - [ ] [steering-committee team](https://github.com/orgs/todogroup/teams/steering-committee) on the TODO Group GitHub organization
 - [ ] Update the Steering Committee email alias on GSuite (LF staff will need to do this one)


### PR DESCRIPTION
When the steering committee membership changes, there are a lot of places where we need to update that information.

This is the first draft of an issue template to make it easier to keep track of all the little bits that need to be twiddled when the membership changes.