### PR TITLE
Update MEMBERS.csv

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -27,7 +27,7 @@ Jon Parise, jon@pinterest.com , jparise, Pinterest
 Jonathan Lipps, jlipps@saucelabs.com, jlipps, Sauce Labs
 Dirk Hohndel, dirkhh@vmware.com, dirkhh, VMware
 Tim Pepper, tpepper@vmware.com, tpepper, VMware
-Stormy Peters, stpeters@redhat.com, -, Red Hat
+Deborah Bryant, dbryant@redhat.com, -, Red Hat
 Craig Northway, craign@qti.qualcomm.com, craigez, Qualcomm Technologies Inc
 Jaehun Lee, jaehun12.lee@samsung.com, -, Samsung
 Jared Smith, jared.smith@capitalone.com, jaredsmith, Capital One
@@ -60,3 +60,5 @@ Seo-Young Isabelle Hwang, seoyoung.hwang@samsung.com, Seo-Young, Samsung
 Ibrahim Haddad, ibrahim@linux.com, , Linux Foundation 
 Michael Phillips, michael.phillips@ni.com, benmont, National Instruments
 Daniel Park, soohong.park@samsung.com, ,Samsung
+Leslie Hawthorn, lhawthor@redhat.com, lhawthorn, Red Hat
+Ruth Suehle, rsuehle@redhat.com, suehle, Red Hat


### PR DESCRIPTION
Updated list to reflect that Deborah Bryant is the Red Hat main representative to the TODO Group, added information for self and Ruth Suehle from Red Hat.