### PR TITLE
Add summary to each section

### DIFF
--- a/resolutions/README.md
+++ b/resolutions/README.md
@@ -6,6 +6,14 @@ them, and for actions taken by the Steering Committee to be documented.
 
 ## Proposing a resolution
 
+### Summary
+
+1. Update [numbers.md](numbers.md)
+1. Copy [resolution template](template/standard) into `proposed`
+1. Send PR (or add to existing PR if applicable)
+
+### Details
+
 Fork this repository, and copy the [resolution template](template/standard.md) into a new
 file in the `proposed` directory. The name of this file should be the next resolution number
 in sequence in the current year, based on the [list](numbers.md). Add a line to that file
@@ -18,6 +26,15 @@ next meeting when the Pull Request is merged.
 
 ## Approving a resolution
 
+### Summary
+
+1. Update proposal w/votes, date, and optionally rationale
+1. Move proposal to `approved`
+1. Push to update the PR
+1. Merge the PR
+
+### Details
+
 If the Steering Committee votes to approve a resolution, then:
 
 * The resolution document will be moved from the `proposed` directory to the `approved`
@@ -28,6 +45,15 @@ approved, the voting results, and the status will be changed from 'Proposed' to 
 
 ## Declining a resolution
 
+### Summary
+
+1. Update proposal w/votes, date, rationale
+1. Move proposal to `declined`
+1. Push to update the PR
+1. Merge the PR
+
+### Details
+
 If the Steering Committee votes to decline a resolution, then:
 
 * The resolution document will be moved from the `proposed` directory to the `declined`
@@ -37,6 +63,16 @@ directory.
 declined, the voting results, and the status will be changed from 'Proposed' to 'Declined'.
 
 ## Deferring a resolution
+
+### Summary
+
+1. Update `Status:` header line in proposal, changing date & status
+1. Add `Deferred to:` header line
+1. Email program manager to ensure proposal review gets onto the agenda for the appropriate date
+1. Push to update the PR
+1. Leave PR open
+
+### Details
 
 If the Steering Committe is unable to reach a consensus on a resolution, this will
 be communicated to the proposer; if the committee requires additional information or


### PR DESCRIPTION
To ensure that we don't forget to update/move files as needed, add a
quick and dirty summary to each section of the resolution process.