### PR TITLE
Reformatted links and added our mission statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 # TODO Group 
 
-The TODO Group is a group of companies who want to collaborate on practices, tools, and other ways to run successful and effective open source projects and programs
+The TODO Group is a group of companies who collaborate on practices, tools, and other ways to run successful and effective open source projects and programs.
 
 ## Charter
 
-You can find our charter online here:
-
-https://github.com/todogroup/governance/blob/master/CHARTER.adoc
-
-If you need it in PDF form, you can download it [here](https://github.com/todogroup/governance/blob/master/TODO%20Charter%20and%20Agreement%20v2.0.pdf).
+Our mission is to identify key policy and process choices related to corporate open source engagement and create tools and educational materials that promote best practices around such engagements. You can learn more about what we do by reading our [charter](https://github.com/todogroup/governance/blob/master/CHARTER.adoc) ([PDF version](https://github.com/todogroup/governance/blob/master/TODO%20Charter%20and%20Agreement%20v2.0.pdf)).
 
 ## TODO Steering Committee (TSC)
 
-The Steering Committee shall be elected for their expertise, contribution to the advancement of open source program management. They are responsible for overall operations and budgetary issues:
+The Steering Committee shall be elected for their expertise and contribution to the advancement of open source program management. They are responsible for overall operations and budgetary issues:
 
 * Chris Aniszczyk (@caniszczyk) - (8/15/2019 -  12/31/2021)
 * Duane O'Brien (@duaneobrien) - (8/15/2019 - 12/31/2021)


### PR DESCRIPTION
Updated the readme to include the mission statement from our charter on the page and got rid of the bare links in favor of ones with anchor text to make things look a bit better.