### PR TITLE
Updated member list

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -18,7 +18,7 @@ Joel Marcey, joelm@fb.com, JoelMarcey, Facebook, #
 Gianugo Rabellino, gianugo.rabellino@microsoft.com, gianugo, Microsoft, #
 Matthew Taylor, matt@numenta.org, rhyolight, Numenta, #
 Benjamin VanEvery, vanevery@box.com, asheepapart, Box, #
-Gil Yehuda, gil@gilyehuda.com, gyehuda, US Bank, #
+Gil Yehuda, gil@gilyehuda.com, gyehuda, US Bank, Yes
 Ashley Wolf, ashleywolf@github.com, ashleywolf, GitHub, #
 Michael Cheng, m@priorart.io, syotfs, Facebook, #
 Andrew Spyker, aspyker@netflix.com, aspyker, Netflix, #


### PR DESCRIPTION
Indicated Gil Yehuda to be the primary contact for the entity he represents