### PR TITLE
MEMBERS.csv: Sort by company, then primary contact, then first name

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -1,80 +1,80 @@
-Name, Email, GitHub, Company, Primary Contact
-John Mark Walker, johnmark.walker@capitalone.com, johnmark, Capital One, #
-Chris Aniszczyk, caniszczyk@gmail.com, caniszczyk, Linux Foundation, #
-Mark Atwood, atwoodm@amazon.com, MarkAtwood, Amazon, yes
-Duane O'Brien, duaneo@indeed.com, DuaneOBrien, Indeed, #
-James Christopherson, james.christopherson@target.com, digitaljames, Target, #
-Luke Faraone, lfaraone@dropbox.com, lfaraone, Dropbox, #
-Paul Holland, paul.holland@hpe.com, peholland, Hewlett Packard Enterprise, Yes
-Jeffrey Jagoda, jeffrey.jagoda@ibm.com, jagoda, IBM, #
-Jamie Jones, jbjonesjr@github.com, jbjonesjr, GitHub, #
-Jeff McAffer, jeffmcaffer@github.com, jeffmcaffer, GitHub, #
-Chris Kelly, #, amateurhuman, #, #
-Will Norris, wnorris@twitter.com, willnorris, Twitter, yes
-William Bartholomew, iamwillbar@github.com, iamwillbar, GitHub, #
-Joel Marcey, joelm@fb.com, JoelMarcey, Meta, yes
-Gianugo Rabellino, gianugo.rabellino@microsoft.com, gianugo, Microsoft, #
-Matthew Taylor, matt@numenta.org, rhyolight, Numenta, #
-Benjamin VanEvery, vanevery@box.com, asheepapart, Box, #
-Gil Yehuda, gil@gilyehuda.com, gyehuda, US Bank, Yes
-Ashley Wolf, ashleywolf@github.com, ashleywolf, GitHub, #
-Michael Cheng, m@priorart.io, syotfs, Meta, #
-Andrew Spyker, aspyker@netflix.com, aspyker, Netflix, #
-Jon Parise, jon@pinterest.com , jparise, Pinterest, #
-Jonathan Lipps, jlipps@saucelabs.com, jlipps, Sauce Labs, #
-Dirk Hohndel, dirkhh@vmware.com, dirkhh, VMware, #
-Tim Pepper, tpepper@vmware.com, tpepper, VMware, #
-Dawn Foster, fosterd@vmware.com, geekygirldawn, VMware, Yes
-Deborah Bryant, dbryant@redhat.com, -, Red Hat, yes
-Craig Northway, craign@qti.qualcomm.com, craigez, Qualcomm Technologies Inc, yes
-Jaehun Lee, jaehun12.lee@samsung.com, -, Samsung, #
-Jared Smith, jared.smith@capitalone.com, jaredsmith, Capital One, #
-Chris Xie, chris.xie@futurewei.com, chrisxie-fw, Futurewei, #
-Jie Liu, liujiejo@huawei.com, -, Huawei, #
-Guy Martin, guy.martin@autodesk.com, guymartin, OASIS Foundation, #
-Simon MacDonald, smacdona@adobe.com, macdonst, Adobe, #
-Patrick Steele-Idem, psteeleidem@ebay.com, patrick-steele-idem, eBay, #
-Mark Matyas, mmatyas@qti.qualcomm.com, mynameistechno, Qualcomm Technologies Inc, #
-Nithya Ruff, nithya_ruff@comcast.com, nruff, Comcast, Yes
-Shilla Saebi, shilla_saebi@cable.comcast.com, shillasaebi, Comcast, #
-Peter Giese, peter.giese@sap.com, , SAP, yes
-Michael Picht, michael.picht@sap.com, , SAP, #
-Philippe Robin, Philippe.Robin@arm.com, , ARM, #
-Andrew Aitken, andrew.aitken@wipro.com, , Wipro, yes
-Jeremy Garcia, jeremy.garcia@datadoghq.com, jeremy-lq, Datadog, yes
-Joel Crabb, joel.crabb@target.com, joel-target, Target, #
-Michael Whitsitt, michael.whitsitt@target.com, michaelswhitsitt, Target, #
-Jerry Tan, tanzhongyi@baidu.com, tanzhongyibidu, Baidu, #
-Dave Zolotusky, dzolo@spotify.com, dzolotusky, Spotify, #
-Sounil Yu, sounil.yu@bankofamerica.com, , Bank of America, #
-Yunbo Wang, wangyunbo@didichuxing.com, , Didi, #
-Manfred Moser, mmoser@walmartlabs.com, mosabua, Walmart, #
-Sue Xia, sxia0@walmart.com, sxia9, Walmart, #
-Kevin P. Fleming, kpfleming@bloomberg.net, kpfleming, Bloomberg, yes
-Josh Simmons, #, joshsimmons, #, #
-Seo-Young Isabelle Hwang, seoyoung.hwang@samsung.com, Seo-Young, Samsung, #
-Ibrahim Haddad, ibrahim@linux.com, , Linux Foundation, #
-Michael Phillips, michael.phillips@ni.com, benmont, National Instruments, #
-Daniel Park, soohong.park@samsung.com, ,Samsung, #
-Leslie Hawthorn, lhawthor@redhat.com, lhawthorn, Red Hat, #
-Ruth Suehle, rsuehle@redhat.com, suehle, Red Hat, #
-Jim Jagielski, jjagielski@salesforce.com, jimjag, Salesforce, yes
-Liam Randall, liam.randall@capitalone.com, LiamRandall, Capital One, #
-Justin Rackliffe, justin.rackliffe@fmr.com, byjrack, Fidelity Investments, #
-Stormy Peters, stopeter@microsoft.com, stormypeters, GitHub, #
-Jeff Wilcox, jwilcox@microsoft.com, jeffwilcox, Microsoft, yes
-Chris Lloyd-Jones, chris.lloyd-jones@avanade.com, Sealjay, Avanade, yes
-Gergely Csatari, gegrely.csatari@nokia.com, CsatariGergely, Nokia, #
-Greg Back, gregory.back@elastic.co, gtback, Elastic, yes
-VM (Vicky) Brasseur, # , vmbrasseur, Wipro, #
-Gilles Gravier, #, gravax, Wipro, #
-Stephen Augustus, augustus@cisco.com, justaugustus, Cisco, yes
-Julia Ferraioli, jferraioli@twitter.com, juliaferraioli, Twitter, #
-Georg Kunz, georg.kunz@ericsson.com, gkunz, Ericsson, yes
-Gunnar Nilsson, gunnar.nilsson@ericsson.com, carvmeister, Ericsson, #
-Yoonhwan Jung, #, #, Samsung, yes
-Tomas Evensen, tomase@xilinx.com, #, Xilinx, #
-Nathalie C. Chan King Choy, nathalie@xilinx.com, nathalie-ckc, Xilinx, yes
-David Panella, dplanella@gitlab.com, #, GitLab, yes
-Thomas Steenbergen, thomas.steenbergen@here.com, tsteenbe, HERE Technologies, yes
-Alyssa Wright, alyssawright@bloomberg.net, #, Bloomberg, yes
+Name,Email,GitHub,Company,Primary Contact
+Chris Kelly,#,amateurhuman,#,#
+Josh Simmons,#,joshsimmons,#,#
+Simon MacDonald,smacdona@adobe.com,macdonst,Adobe,#
+Mark Atwood,atwoodm@amazon.com,MarkAtwood,Amazon,yes
+Philippe Robin,Philippe.Robin@arm.com,,ARM,#
+Chris Lloyd-Jones,chris.lloyd-jones@avanade.com,Sealjay,Avanade,yes
+Jerry Tan,tanzhongyi@baidu.com,tanzhongyibidu,Baidu,#
+Sounil Yu,sounil.yu@bankofamerica.com,,Bank of America,#
+Alyssa Wright,alyssawright@bloomberg.net,#,Bloomberg,yes
+Kevin P. Fleming,kpfleming@bloomberg.net,kpfleming,Bloomberg,yes
+Benjamin VanEvery,vanevery@box.com,asheepapart,Box,#
+Jared Smith,jared.smith@capitalone.com,jaredsmith,Capital One,#
+John Mark Walker,johnmark.walker@capitalone.com,johnmark,Capital One,#
+Liam Randall,liam.randall@capitalone.com,LiamRandall,Capital One,#
+Stephen Augustus,augustus@cisco.com,justaugustus,Cisco,yes
+Nithya Ruff,nithya_ruff@comcast.com,nruff,Comcast,yes
+Shilla Saebi,shilla_saebi@cable.comcast.com,shillasaebi,Comcast,#
+Jeremy Garcia,jeremy.garcia@datadoghq.com,jeremy-lq,Datadog,yes
+Yunbo Wang,wangyunbo@didichuxing.com,,Didi,#
+Luke Faraone,lfaraone@dropbox.com,lfaraone,Dropbox,#
+Patrick Steele-Idem,psteeleidem@ebay.com,patrick-steele-idem,eBay,#
+Greg Back,gregory.back@elastic.co,gtback,Elastic,yes
+Georg Kunz,georg.kunz@ericsson.com,gkunz,Ericsson,yes
+Gunnar Nilsson,gunnar.nilsson@ericsson.com,carvmeister,Ericsson,#
+Justin Rackliffe,justin.rackliffe@fmr.com,byjrack,Fidelity Investments,#
+Chris Xie,chris.xie@futurewei.com,chrisxie-fw,Futurewei,#
+Ashley Wolf,ashleywolf@github.com,ashleywolf,GitHub,#
+Jamie Jones,jbjonesjr@github.com,jbjonesjr,GitHub,#
+Jeff McAffer,jeffmcaffer@github.com,jeffmcaffer,GitHub,#
+Stormy Peters,stopeter@microsoft.com,stormypeters,GitHub,#
+William Bartholomew,iamwillbar@github.com,iamwillbar,GitHub,#
+David Panella,dplanella@gitlab.com,#,GitLab,yes
+Thomas Steenbergen,thomas.steenbergen@here.com,tsteenbe,HERE Technologies,yes
+Paul Holland,paul.holland@hpe.com,peholland,Hewlett Packard Enterprise,yes
+Jie Liu,liujiejo@huawei.com,-,Huawei,#
+Jeffrey Jagoda,jeffrey.jagoda@ibm.com,jagoda,IBM,#
+Duane O'Brien,duaneo@indeed.com,DuaneOBrien,Indeed,#
+Chris Aniszczyk,caniszczyk@gmail.com,caniszczyk,Linux Foundation,#
+Ibrahim Haddad,ibrahim@linux.com,,Linux Foundation,#
+Joel Marcey,joelm@fb.com,JoelMarcey,Meta,yes
+Michael Cheng,m@priorart.io,syotfs,Meta,#
+Jeff Wilcox,jwilcox@microsoft.com,jeffwilcox,Microsoft,yes
+Gianugo Rabellino,gianugo.rabellino@microsoft.com,gianugo,Microsoft,#
+Michael Phillips,michael.phillips@ni.com,benmont,National Instruments,#
+Andrew Spyker,aspyker@netflix.com,aspyker,Netflix,#
+Gergely Csatari,gegrely.csatari@nokia.com,CsatariGergely,Nokia,#
+Matthew Taylor,matt@numenta.org,rhyolight,Numenta,#
+Guy Martin,guy.martin@autodesk.com,guymartin,OASIS Foundation,#
+Jon Parise,jon@pinterest.com,jparise,Pinterest,#
+Craig Northway,craign@qti.qualcomm.com,craigez,Qualcomm Technologies Inc,yes
+Mark Matyas,mmatyas@qti.qualcomm.com,mynameistechno,Qualcomm Technologies Inc,#
+Deborah Bryant,dbryant@redhat.com,-,Red Hat,yes
+Leslie Hawthorn,lhawthor@redhat.com,lhawthorn,Red Hat,#
+Ruth Suehle,rsuehle@redhat.com,suehle,Red Hat,#
+Jim Jagielski,jjagielski@salesforce.com,jimjag,Salesforce,yes
+Yoonhwan Jung,#,#,Samsung,yes
+Daniel Park,soohong.park@samsung.com,,Samsung,#
+Jaehun Lee,jaehun12.lee@samsung.com,-,Samsung,#
+Seo-Young Isabelle Hwang,seoyoung.hwang@samsung.com,Seo-Young,Samsung,#
+Peter Giese,peter.giese@sap.com,,SAP,yes
+Michael Picht,michael.picht@sap.com,,SAP,#
+Jonathan Lipps,jlipps@saucelabs.com,jlipps,Sauce Labs,#
+Dave Zolotusky,dzolo@spotify.com,dzolotusky,Spotify,#
+James Christopherson,james.christopherson@target.com,digitaljames,Target,#
+Joel Crabb,joel.crabb@target.com,joel-target,Target,#
+Michael Whitsitt,michael.whitsitt@target.com,michaelswhitsitt,Target,#
+Will Norris,wnorris@twitter.com,willnorris,Twitter,yes
+Julia Ferraioli,jferraioli@twitter.com,juliaferraioli,Twitter,#
+Gil Yehuda,gil@gilyehuda.com,gyehuda,US Bank,yes
+Dawn Foster,fosterd@vmware.com,geekygirldawn,VMware,yes
+Dirk Hohndel,dirkhh@vmware.com,dirkhh,VMware,#
+Tim Pepper,tpepper@vmware.com,tpepper,VMware,#
+Manfred Moser,mmoser@walmartlabs.com,mosabua,Walmart,#
+Sue Xia,sxia0@walmart.com,sxia9,Walmart,#
+Andrew Aitken,andrew.aitken@wipro.com,,Wipro,yes
+Gilles Gravier,#,gravax,Wipro,#
+VM (Vicky) Brasseur,#,vmbrasseur,Wipro,#
+Nathalie C. Chan King Choy,nathalie@xilinx.com,nathalie-ckc,Xilinx,yes
+Tomas Evensen,tomase@xilinx.com,#,Xilinx,#


### PR DESCRIPTION
@anajsana -- I was finding the members list a little hard to read through (especially when trying to understand who was the primary contact for a particular company).

This PR sorts the member list by:
- company, then:
- primary contact, then:
- first name

Hope that's okay! :)

Signed-off-by: Stephen Augustus <foo@auggie.dev>