### PR TITLE
.github: Add CODEOWNERS and tidy settings.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# the following users/teams will be requested for
+# review when someone opens a pull request.
+* @todogroup/steering-committee
+
+# Enforces admin protections for repo configuration via probot settings app.
+# ref: https://github.com/probot/settings#security-implications
+.github/settings.yml @todogroup/steering-committee

--- a/.github/ISSUE_TEMPLATE/sc-change.md
+++ b/.github/ISSUE_TEMPLATE/sc-change.md
@@ -17,8 +17,6 @@ labels: sc-change
 
 - [ ] [README](https://github.com/todogroup/governance/blob/master/README.md) on the governance repo
 - [ ] The SC member list on the [resolution template](https://github.com/todogroup/governance/blob/master/resolutions/template/standard.md)
-- [ ] `collaborators` array in [settings.yml](https://github.com/todogroup/governance/blob/master/.github/settings.yml)
 - [ ] [steering-committee team](https://github.com/orgs/todogroup/teams/steering-committee) on the TODO Group GitHub organization
 - [ ] The Steering Committee email alias on GSuite (LF staff will need to do this one)
 - [ ] Invitees on Steering Committee meeting calendar event
-

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -24,13 +24,13 @@ teams:
 # See https://docs.github.com/en/rest/reference/collaborators for available options
 collaborators:
   - username: caniszczyk
-    permission: admin
+    permission: maintain
 
   - username: DuaneOBrien
-    permission: admin
+    permission: maintain
 
   - username: kpfleming
-    permission: admin
+    permission: maintain
 
   - username: jeffmcaffer
-    permission: admin
+    permission: maintain

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -9,33 +9,20 @@ repository:
 
   # A URL with more information about the repository
   homepage: https://todogroup.org
-  
-  # Collaborators: give specific users access to this repository.
 
+# See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
+teams:
+  - name: steering-committee
+    # The permission to grant the team. Can be one of:
+    # * `pull` - can pull, but not push to or administer this repository.
+    # * `push` - can pull and push, but not administer this repository.
+    # * `admin` - can pull, push and administer this repository.
+    # * `maintain` - Recommended for project managers who need to manage the repository without access to sensitive or destructive actions.
+    permission: admin
+
+# Collaborators: give specific users access to this repository.
+# See https://docs.github.com/en/rest/reference/collaborators for available options
 collaborators:
-  # Steering Committee
-  - username: ashleywolf
-    permission: admin
-
-  - username: geekygirldawn
-    permission: admin
-
-  - username: itprofjacobs
-    permission: admin
-
-  - username: justaugustus
-    permission: admin
-
-  - username: shillasaebi
-    permission: admin
-
-  - username: tsteenbe
-    permission: admin
-
-  - username: vmbrasseur
-    permission: admin
-
-  # TODO members
   - username: caniszczyk
     permission: admin
 


### PR DESCRIPTION
- .github: Add CODEOWNERS
- .github: Delegate SC repo permissions by team, instead of username
- .github/settings.yml: Ratchet collaborator perms down to `maintain`

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @todogroup/steering-committee 