### PR TITLE
.github/settings.yml: Remove `kpfleming` as maintainer

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -29,8 +29,5 @@ collaborators:
   - username: DuaneOBrien
     permission: maintain
 
-  - username: kpfleming
-    permission: maintain
-
   - username: jeffmcaffer
     permission: maintain


### PR DESCRIPTION
I am no longer a maintainer of this repository (and I suspect that Duane and Jeff should no longer be listed either, so the SC election-cycle process likely needs an additional step to update the list of maintainers of this repo).