### PR TITLE
Create general-member-onboarding.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-member-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/general-member-onboarding.md
@@ -1,0 +1,45 @@
+---
+name: TODO General Member Onboarding - New Organization
+about: Member onboarding
+title: "[GENERAL MEMBER ONBOARDING] Organization"
+labels: member onboarding
+assignees: anajsana
+---
+
+# Welcome to TODO General Member Onboarding!
+This is an issue created to help onboard your OSPO team into the TODO Group after the [TODO General Membership Application](https://joinnow.todogroup.org/) has been validated and processed. 
+This checklist will help you to sync across the main TODO communication channels and initiatives.
+
+## Communication channels
+
+Please ensure that you:
+
+- [ ] Join TODO [Slack](https://slack.todogroup.org/)
+- [ ] Join TODO public [Community Mailing List](https://docs.google.com/forms/d/e/1FAIpQLSeU0YGM_IJ6gY8E5IIiwXKD_FZi3kAVc4E9_-3dtTDyKMSjdA/viewform)
+- [ ] Follow us on [Twitter](https://twitter.com/todogroup)
+- [ ] Follow us on [LinkedIn](https://www.linkedin.com/company/todo-group/)
+- [ ] Have push permissions in the [TODO GH Organization](https://github.com/orgs/todogroup/people)
+- [ ] Are aware of the OSPO [Forum Discussions](https://github.com/todogroup/ospology/discussions)
+- [ ] Join OSPO [Newsletter](https://www.getrevue.co/profile/osponews)
+
+Also, please ask TODO PM @anajsana to add you to the different channels Private TODO General Members Channels and ensure that you:
+
+- [ ] Have access at General Member's mailing list
+- [ ] Have access at General Member's slack channel 
+- [ ] Are introduced to other TODO General Members through TODO General Member Mailing List
+
+
+## Meetings and Calls
+
+- [ ] [OSPOlogy Community Calls](https://community.linuxfoundation.org/todo-group/) (Monthly on Wednesdays)
+- [ ] TODO [EU Sync Meetings](https://community.linuxfoundation.org/todo-group-europe/) (Monthly on Thursdays)
+>Registration prior to the meeting is required. See the ospology repo to learn more
+- [ ] General Member's Touchpoint calls (an invite is sent once you are added to the TODO private mailing list): Bi-weekly informal meetings on Fridays
+- [ ] General Members's AMA session (an invite is sent once you are added to the TODO private mailing list): Quarterly on mondays
+
+
+## Resources and initiatives
+
+- [ ] Review the existing TODO GH Repos in the Org `README.md` file: https://github.com/todogroup
+- [ ] Read TODO Website'sQ&A section: https://todogroup.org/faq/
+- [ ] Read the [TODO Charter](https://github.com/todogroup/governance/blob/main/CHARTER.adoc)


### PR DESCRIPTION
This commit creates an issue template to ease the onboarding when a TODO General Member Application has been processed and approved. This also allows the whole community to be up to date about those new organizations that are joining as General Members in a more open way.