### PR TITLE
fix onboarding guide link for onboarding issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding-general-member.md
+++ b/.github/ISSUE_TEMPLATE/onboarding-general-member.md
@@ -63,4 +63,4 @@ they have invites for the following meetings:
 
 ## Resources and initiatives
 
-- [ ] Ensure members are aware of the General Members [onboarding guide](/onboarding/general-member.md)
+- [ ] Ensure members are aware of the General Members [onboarding guide](https://github.com/todogroup/governance/blob/main/onboarding/general-member.md)


### PR DESCRIPTION
The old link pointed to a 404. I've fixed the link so now it points to the right `.md` file