### PR TITLE
members: Set Jie Liu as Huawei primary contact

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -47,7 +47,7 @@ William Bartholomew,iamwillbar,GitHub,#
 David Panella,#,GitLab,yes
 Thomas Steenbergen,tsteenbe,HERE Technologies,yes
 Paul Holland,peholland,Hewlett Packard Enterprise,yes
-Jie Liu,-,Huawei,#
+Jie Liu,-,Huawei,yes
 Jeffrey Jagoda,jagoda,IBM,#
 Duane O'Brien,DuaneOBrien,Indeed,#
 Jessica Marz,jkmarz,Intel,#


### PR DESCRIPTION
confirm Huawei main contact person