### PR TITLE
members: update point of contact for Twitter

### DIFF
--- a/MEMBERS.csv
+++ b/MEMBERS.csv
@@ -4,6 +4,7 @@ Jared Smith,jaredsmith,#,#
 John Mark Walker,johnmark,#,#
 Josh Simmons,joshsimmons,#,#
 Liam Randall,LiamRandall,#,#
+Will Norris,willnorris,#,#
 Simon MacDonald,macdonst,Adobe,#
 Greg Haynes,#,Autodesk,yes
 Josep Prat,jlprat,Aiven,yes
@@ -102,7 +103,7 @@ Dave Zolotusky,dzolotusky,Spotify,#
 James Christopherson,digitaljames,Target,#
 Joel Crabb,joel-target,Target,#
 Michael Whitsitt,michaelswhitsitt,Target,#
-Will Norris,willnorris,Twitter,yes
+Eitan Adler,grimreaper,Twitter,yes
 Stephanie Lieggi,slieggi,UC Santa Cruz,yes
 Carlos Maltzahn,carlosmalt,UC Santa Cruz,#
 Gil Yehuda,gyehuda,US Bank,yes


### PR DESCRIPTION
I'm not completely sure what the protocol is for emeritus(?) members at the top of this file, but I've added myself there for now.  I'm also happy to remove myself entirely if that's more appropriate.