### PR TITLE
Fix Slack invite links

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding-general-member.md
+++ b/.github/ISSUE_TEMPLATE/onboarding-general-member.md
@@ -37,7 +37,7 @@ This is an issue created to onboard new TODO Group General Members.
 
 Ensure that member representatives have joined the following:
 
-- [ ] [TODO Group Slack](https://slack.todogroup.org/)
+- [ ] [TODO Group Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-169ok18cz-Pi6tpVHTeW9254d1FpkLew)
 - [ ] [Community Mailing List](https://docs.google.com/forms/d/e/1FAIpQLSeU0YGM_IJ6gY8E5IIiwXKD_FZi3kAVc4E9_-3dtTDyKMSjdA/viewform)
 
 ### GitHub

--- a/onboarding/community.md
+++ b/onboarding/community.md
@@ -5,7 +5,7 @@ Welcome to the OSPology!
 If you are new to OSPOlogy Community, this guide should provide helpful onboarding resources. If you run into any issues during the onboarding process, 
 please reach out to the TODO Group Program Manager (@anajsana).
 
-- [📖 OSPOlogy Community Onboarding](#-todo-community-onboarding)
+- [📖 OSPOlogy Community Onboarding](#-ospology-community-onboarding)
   - [🙋 Getting started](#-getting-started)
     - [📝 Contribution guides](#-contribution-guides)
   - [💬 Communication channels](#-communication-channels)

--- a/onboarding/general-member.md
+++ b/onboarding/general-member.md
@@ -14,7 +14,7 @@ If you run into any issues during the onboarding process, please reach out to th
   - [Contribution guides](#contribution-guides)
 - [Communication channels](#communication-channels)
   - [Discussions](#discussions)
-  - [Newsletters](#newsletters)
+  - [Newsletter](#newsletter)
   - [Registration required](#registration-required)
   - [Social media](#social-media)
   - [GitHub](#github)

--- a/onboarding/general-member.md
+++ b/onboarding/general-member.md
@@ -63,7 +63,7 @@ publicly available, but you can also subscribe to receive it via email!
 Public communication channels that need registration via third-party platforms
 to either see or interact with content e.g., Slack, LF Community Platform, GitHub
 
-- [TODO Group Slack](https://slack.todogroup.org/)
+- [TODO Group Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-169ok18cz-Pi6tpVHTeW9254d1FpkLew)
 - [Community Mailing List](https://docs.google.com/forms/d/e/1FAIpQLSeU0YGM_IJ6gY8E5IIiwXKD_FZi3kAVc4E9_-3dtTDyKMSjdA/viewform)
 
 ### Social media


### PR DESCRIPTION
Fixes #287.

Updates onboarding documentation to remove broken Slack signup link (https://slack.todogroup.org/) and instead use a consistent invite link across all docs. Also fixes some Markdown link fragments.