### PR TITLE
gitvote: Add initial configuration

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,0 +1,36 @@
+# GitVote configuration file reference: https://github.com/cncf/gitvote/blob/main/docs/config/.gitvote.yml
+
+profiles:
+  default:
+    duration: 4w
+    pass_threshold: 67
+    allowed_voters:
+      teams: gitvote-steering
+      exclude_team_maintainers: true
+    periodic_status_check: 1 week
+    close_on_passing: true
+
+# Automation (optional)
+#
+# Create votes automatically on PRs when any of the files affected by the PR
+# match any of the patterns provided. Patterns must follow the gitignore
+# format (https://git-scm.com/docs/gitignore#_pattern_format).
+#
+# Each automation rule must include a list of patterns and the profile to use
+# when creating the vote. This allows creating votes automatically using the
+# desired configuration based on the patterns matched. Rules are processed in
+# the order provided, and the first match wins.
+#
+# automation:
+#   enabled: true
+#   rules:
+#     - patterns:
+#         - "README.md"
+#         - "*.txt"
+#       profile: default
+#
+automation:
+  enabled: false
+  rules:
+    - patterns: []
+      profile: profile1


### PR DESCRIPTION
GitVote configuration file reference: https://github.com/cncf/gitvote/blob/main/docs/config/.gitvote.yml

Quick explanation of the config:
The default GitVote profile is set to seek votes from the `gitvote-steering` GitHub team.
Votes are open for 4 weeks, have daily and weekly checks, and will automatically conclude once 67% of Steering has passed.

Two notes:
- The `gitvote-steering` GitHub team was created so that the vote percentage is calculated strictly from the membership of the Steering Committee. While GitVote supports excluding team maintainers (which you can see reflected in the config file in this PR), @anajsana is an organization owner, which means she cannot be set as a team maintainer (and I'm not going to remove her from the `steering-committee` GitHub team without a discussion)
- The pass threshold for a vote is currently set to 67 to account for the fact that @lhawthorn is not currently a member of the GitHub organization. While percentage-wise, that's a two-thirds majority, it actually ensures that we have achieved a simple majority (51%) or four (4) passing electronic votes, as required by [our charter, at this point in time](https://github.com/todogroup/governance/blob/fa43efe6db27254bdc192e09e203651dc0de146f/GM-SC-CHARTER.adoc). This pass threshold can be updated to 51% once Leslie joins the org.

ref: https://github.com/todogroup/governance/issues/326