### PR TITLE
gitvote: Fix teams configuration

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -5,7 +5,8 @@ profiles:
     duration: 4w
     pass_threshold: 67
     allowed_voters:
-      teams: gitvote-steering
+      teams:
+      - gitvote-steering
       exclude_team_maintainers: true
     periodic_status_check: 1 week
     close_on_passing: true


### PR DESCRIPTION
Fixing a minor configuration error from https://github.com/todogroup/governance/pull/327, which got flagged by [this vote test comment](https://github.com/todogroup/governance/issues/326#issuecomment-2080407187).

```console
profiles.default.allowed_voters.teams: invalid type: string "gitvote-steering", expected a sequence at line 8 column 14
```