### PR TITLE
gitvote: Do not exclude team maintainers from voting

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -7,7 +7,7 @@ profiles:
     allowed_voters:
       teams:
       - gitvote-steering
-      exclude_team_maintainers: true
+      exclude_team_maintainers: false
     periodic_status_check: 1 week
     close_on_passing: true
 


### PR DESCRIPTION
Some Steering members are also GitHub organization owners, which will automatically designate us as maintainers of any team we hold membership in (like `gitvote-steering`).

This config change allows the subset of Steering members who are also GitHub org owners to have binding votes.

Opting to explicitly set this config option to `false`, instead of assuming this will always be the default, so we don't get surprised in the future.

ref: https://github.com/todogroup/governance/issues/326#issuecomment-2080414027