### PR TITLE
gitvote: Update pass threshold to a simple majority

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -3,7 +3,7 @@
 profiles:
   default:
     duration: 4w
-    pass_threshold: 67
+    pass_threshold: 51
     allowed_voters:
       teams:
       - gitvote-steering


### PR DESCRIPTION
The pass threshold for a vote was set to 67 to account for the fact that @lhawthorn was not a member of the GitHub organization.

Now that Leslie has joined the org, this updates the gitvote pass threshold to align with the simple majority (51%) or four (4) passing electronic votes required by our charter, at this point in time.

Calling for a review from @anajsana or a member of @todogroup/steering-committee, as this will close #326.