### PR TITLE
Steering term and affiliation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In addition to the monthly calls, most of the Steering Committee’s work is con
 
 <details>
   <summary>
-    <strong>🙋‍♀️ Steering Committee Members from 2023 to 2025</strong>
+    <strong>🙋‍♀️ Steering Committee Members</strong>
   </summary><br />
    
 | Name | Company | Elected/Appointed | Term |
@@ -55,10 +55,10 @@ In addition to the monthly calls, most of the Steering Committee’s work is con
 | [Leslie Hawthorn](https://github.com/lhawthorn) | RedHat | Elected | 2023-01-01 to 2024-12-31 |
 | [Georg Kunz](https://github.com/gkunz) | Ericsson | Appointed | 2023-01-01 to 2024-12-31 |
 | [Annania Melaku](https://github.com/annania) | NGINX | Appointed | 2023-01-01 to 2024-12-31 |
-| [Ashley Wolf](https://github.com/ashleywolf) | GitHub | Elected | 2024-01-01 to 2026-12-31 |
-| [Brittany Istenes](https://github.com/BrittanyIstenes) | Fannie Mae | Appointed | 2024-01-01 to 2026-12-31 |
-| [Nik Peters](https://github.com/nikpete) | Porsche | Elected | 2024-01-01 to 2026-12-31 |
-| [Stephen Augustus](https://github.com/justaugustus) | Cisco | Elected | 2024-01-01 to 2026-12-31 |
+| [Ashley Wolf](https://github.com/ashleywolf) | GitHub | Elected | 2024-01-01 to 2025-12-31 |
+| [Brittany Istenes](https://github.com/BrittanyIstenes) | Fannie Mae | Appointed | 2024-01-01 to 2025-12-31 |
+| [Nik Peters](https://github.com/nikpete) | Porsche | Elected | 2024-01-01 to 2025-12-31 |
+| [Stephen Augustus](https://github.com/justaugustus) | Cisco | Elected | 2024-01-01 to 2025-12-31 |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ In addition to the monthly calls, most of the Steering Committee’s work is con
    
 | Name | Company | Elected/Appointed | Term |
 | --- | --- | --- | --- |
-| [Leslie Hawthorn](https://github.com/lhawthorn) | RedHat | Elected | 2023-01-01 to 2024-12-31 |
+| [Leslie Hawthorn](https://github.com/lhawthorn) | Red Hat | Elected | 2023-01-01 to 2024-12-31 |
 | [Georg Kunz](https://github.com/gkunz) | Ericsson | Appointed | 2023-01-01 to 2024-12-31 |
-| [Annania Melaku](https://github.com/annania) | NGINX | Appointed | 2023-01-01 to 2024-12-31 |
+| [Annania Melaku](https://github.com/annania) | F5 — NGINX | Appointed | 2023-01-01 to 2024-12-31 |
 | [Ashley Wolf](https://github.com/ashleywolf) | GitHub | Elected | 2024-01-01 to 2025-12-31 |
 | [Brittany Istenes](https://github.com/BrittanyIstenes) | Fannie Mae | Appointed | 2024-01-01 to 2025-12-31 |
 | [Nik Peters](https://github.com/nikpete) | Porsche | Elected | 2024-01-01 to 2025-12-31 |
-| [Stephen Augustus](https://github.com/justaugustus) | Cisco | Elected | 2024-01-01 to 2025-12-31 |
+| [Stephen Augustus](https://github.com/justaugustus) | Independent | Elected | 2024-01-01 to 2025-12-31 |
 
 </details>
 


### PR DESCRIPTION
- Correct Steering Committee terms

  Reflect the correct two-year terms for members with terms starting
  in 2024.

- Minor fixes for Steering Committee affiliations

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @anajsana 