### PR TITLE
Updates to TODO OSPO Ambassador program documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/todo-ospo-ambassador-request.md
+++ b/.github/ISSUE_TEMPLATE/todo-ospo-ambassador-request.md
@@ -8,14 +8,14 @@ assignees: anajsana
 
 # TODO OSPO Ambassador Request
 
-This is an issue created to request to become an OSPO Ambassador. If you (as individual) are interested to apply, please make sure you have (1) read the [TODO OSPO Ambassador Program documentation](https://github.com/todogroup/governance/blob/main/TODO-OSPO-Ambassador-Program.md)
+This is an issue to request becoming an OSPO Ambassador. If you (as individual) are interested to apply, please make sure you have (1) read the [TODO OSPO Ambassador Program documentation](https://github.com/todogroup/governance/blob/main/TODO-OSPO-Ambassador-Program.md)
 and (2) fulfill the requirements from the Pre-submission checklist.
 
-## Pre-submission checklist:
+## Pre-submission checklist
 
 - [ ] I am 18 years of age or older
-- [ ] I abide the [TODO Code Of Conduct](https://todogroup.org/code-of-conduct/)
-- [ ] I abide the [LF antitrust policy](https://www.linuxfoundation.org/legal/antitrust-policy)
+- [ ] I abide by the [TODO Code Of Conduct](https://todogroup.org/code-of-conduct/)
+- [ ] I abide by the [LF antitrust policy](https://www.linuxfoundation.org/legal/antitrust-policy)
 - [ ] I confirm I meet AT LEAST ONE of the criteria documented at [TODO OSPO Ambassador Program documentation](https://github.com/todogroup/governance/blob/main/TODO-OSPO-Ambassador-Program.md)
 
 ## Contact Information
@@ -28,20 +28,24 @@ We would need the following information about you to get in contact if elected:
 - GitHub or GitLab Handle
 - (Optional) Frediverse Handle
 
-## Current involvement in TODO Community
+## Current involvement in the TODO Community
 
 Who are you?
 
 - [ ] An active contributor to a TODO initiative (OSPOlogy, OSPO Landscape, Website, OSPO Book, etc)
 - [ ] A representative from a TODO General Member or OSPO Associate organization
 - [ ] An OSPO Local Organizer and/or OSPOlogy Organizer
-- [ ] An active leader in the TODO community with a minimum of 1 year of experience in:
-    * Organizing events (virtual/in-person)
-    * Speaking at events
-    * Mentoring others 
-    * Creating content (e.g., blogs, videos, etc.)
+- [ ] An active leader in the TODO community with a minimum of 1 year of experience in
+  - Organizing events (virtual/in-person)
+  - Speaking at events
+  - Mentoring others
+  - Creating content (e.g., blogs, videos, etc.)
 
-## REQUIRED: What do you expect from TODO Group as an TODO OSPO Ambassador? Whow would you help the community to thrive?
+Please provide a selection of pointers to your active involvement in the TODO community. This can include community calls and/or OSPOlogy live micro-conferences you participated in, PRs, issues, mailing list posts, recordings of talks and presentations, or any other relevant contribution to the TODO group community.
 
-This is a very important section to understand how you would like to help the OSPO Ecosystem and engage in the TODO community. 
-Here you can also provide links to resources (blogs on OSPOs, Community calls and/or OSPOlogy live micro-conferences where you participated, etc.).
+## Your goals and activities as TODO OSPO Ambassador
+
+Describe your goals as a TODO OSPO Ambassador:
+
+- How you are intending to help the community to thrive?
+- Which activities are you intending to support and/or drive?

--- a/TODO-OSPO-Ambassador-Program.md
+++ b/TODO-OSPO-Ambassador-Program.md
@@ -1,33 +1,42 @@
 # 👩‍🏫 TODO OSPO Ambassador Program (Individuals)
-*TODO OSPO Ambassadors (TOAs) are official advocates within TODO helping the OSPO ecosystem
+
+TODO OSPO Ambassadors (TOAs) are official advocates within the TODO Group community who are supporting the OSPO ecosystem.
+
 ## 🧩 Responsibilities
 
 The TODO OSPO Ambassador Program encompasses a group of community leaders who provide support, training, mentorship, guidance, and rewards to:
 
-* Engage and enable the TODO community through local meetups, OSPOlogy meetings, OSPO content, and mentoring
+* Engage and enable the TODO community through local meetups, OSPOlogy meetings, OSPO-focused content, and mentoring
 * Foster strong community collaboration and relationships
 * Attract and onboard new community participants
-* Provide valuable input and feedback to TODO about community programs and initiatives
+* Provide valuable input and feedback to the TODO community about community programs and initiatives
 * Advocate OSPO best practices and TODO initiatives globally
 
 ## ✅ Requirements
-Program requirements for becoming an official TODO OSPO Ambassador are:
+
+The program requirements for becoming an official TODO OSPO Ambassador are:
+
 * Must be 18 years of age or older
 * Must follow the [TODO Code Of Conduct](https://todogroup.org/code-of-conduct/)
 * Must comply with [LF antitrust policy](https://www.linuxfoundation.org/legal/antitrust-policy)
-* Must meet AT LEAST ONE of the following criteria:
-  * An active contributor to a TODO initiative (OSPOlogy, OSPO Landscape, Website, OSPO Book, etc.)
-  * A representative from a TODO General Member or OSPO Associate organization
-  * An OSPO Local Organizer and/or OSPOlogy Organizer
-  * An active leader in the TODO community with a minimum of 1 year of experience in:
-    * Organizing events (virtual/in-person)
-    * Speaking at events
-    * Mentoring others 
-    * Creating content (e.g., blogs, videos, etc.)
-    
+* Must be a representative from a TODO General Member or OSPO Associate organization
+
+## 🔍 Evaluation Criteria
+
+Applicants must meet at least one of the following criteria:
+
+* An active contributor to a TODO initiative (OSPOlogy, OSPO Landscape, Website, OSPO Book, etc.)
+* An organizer of OSPO-related or TODO Group related events, such as OSPOlogy.live events or local meetups
+* An active leader in the TODO community with a minimum of 1 year of experience in:
+  * Organizing events (virtual/in-person)
+  * Speaking at events
+  * Mentoring others
+  * Creating content (e.g., blogs, videos, etc.)
+
 ## 🚀 Benefits
 
-As a TOA, you are also eligible for Ambassador specific benefits, such as:
+As a TODO OSPO Ambassador, you are also eligible for Ambassador specific benefits, such as:
+
 * Gain recognition for your expertise and contributions to the community
 * Network with equally passionate Ambassadors globally
 * Receive support from the TODO and LF community platforms for hosting events, speaking, creating content, or mentoring others
@@ -35,26 +44,32 @@ As a TOA, you are also eligible for Ambassador specific benefits, such as:
 * Enjoy exclusive swag and giveaways
 * Receive a TODO OSPO Ambassadors Credly badge issued by the Linux Foundation
 
-## 🙋‍♀️ Frequent Asked Questions:
+## 🙋‍♀️ Frequent Asked Questions
 
 ### What is the process for becoming an Ambassador?
+
 To become an Ambassador, an individual must review and meet the current requirements. We invite you to [submit your application for consideration](https://github.com/todogroup/governance/issues/new/choose) if you meet the requirements.
 
+### When can I apply?
+
+You can apply at any time throughout the year, given that you meet the application requirements.
+
 ### Is the TODO OSPO Ambassador (TOAs) a paid position?
+
 No, the TODO OSPO Ambassador is not a paid position. However, TOAs will receive rewards like limited edition swag and exclusive discounts to LF events for their service.
 
 ### How does changing organizations or ceasing activities within an organization affect Ambassador status?
+
 The Ambassador title is granted to an individual, regardless of their affiliation. Thus, moving to a different organization or ceasing activities in a given organization does not affect the Ambassador's title unless the individual determines to no longer be able to commit to the duties of a TODO OSPO Ambassador.
 
 ### How long does my ambassadorship last?
-All ambassadorships will be a two-year commitment. For example, an Ambassador accepted in November 2023 will serve until November 2025. The Ambassador's 
-title will automatically renew every two years unless the individual requests in writing via email not to continue with their title, or if no activity has 
-been recorded during the two-year period.
 
-## Who do I contact with questions?
-For questions, please contact info@todogroup.org
+All ambassadorships will be a two-year commitment. For example, an Ambassador accepted in November 2023 will serve until November 2025. The Ambassador's title will automatically renew every two years unless the individual requests in writing via email not to continue with their title, or if no activity has been recorded during the two-year period.
 
+### Who do I contact with questions?
+
+For questions, please contact <info@todogroup.org>
 
 ## 💚 Attribution
 
-This Ambassador Program is adapted from the CNCF Ambassador Program, version 2.0, available at https://www.cncf.io/people/ambassadors/.
+This Ambassador Program is adapted from the CNCF Ambassador Program, version 2.0, available at <https://www.cncf.io/people/ambassadors/>.


### PR DESCRIPTION
Updates to the documentation of the TODO OSPO Ambassador program. Clarification of requirements and obligations. Additional editorial changes and markdown syntax fixes.

Closes #367