### PR TITLE
Add TODO Group strategic goals for 2026

### DIFF
--- a/goals.md
+++ b/goals.md
@@ -28,7 +28,7 @@ Support TODO members and working groups in sharing guidance and reusable resourc
 
 - [ ] Participate in ask-me-anything, birds of a feather or expert-led panel discussions on these topics at major LF events
 - [ ] Advice on OSPOlogy and OSPOCon-branded programs by providing guidance on themes and formats, and speaking at sessions when possible
-- [ ] Connect with TODO Ambassadors and Working Group Chairs and provide them with resources and expert guidance to help them present on these cases
+- [ ] Connect with TODO Ambassadors and Working Group Chairs and provide them with resources and expert guidance to help them present their work at LF events.
 - [ ] Support release planning of TODO resources and presentation opportunities at events
 - [ ] Coordinate with sister ecosystems (OpenSSF, OpenChain, InnerSource Commons, CURIOSS, CNCF, LF Europe, CHAOSS) and local OSPO communities to co-present and/or co-develop resources and ensure the TODO community stays connected to major conversations on AI, software supply chain security, and regulatory trends
 

--- a/goals.md
+++ b/goals.md
@@ -22,7 +22,7 @@ Support TODO members and working groups in sharing guidance and reusable resourc
 
 - How organizations adopt and contribute to open source AI as part of their AI strategy
 - Use Cases that connect OSPOs with security, legal, and platform teams beyond open source policy
-- How OSPO practice at enterprises links to broader public-interest frameworks (e.g UN Open Source Goals, Academic Research, etc)
+- How OSPO practices in enterprises link to broader public-interest frameworks (e.g., UN Open Source Goals, Academic Research, etc.)
 
 **The Steering Committee is committed to:**
 

--- a/goals.md
+++ b/goals.md
@@ -26,7 +26,7 @@ Support TODO members and working groups in sharing guidance and reusable resourc
 
 **The Steering Committee is committed to:**
 
-- [ ] Participate in ask-me-anything, birds of a feather or expert-led panel discussions on these topics at major LF events
+- [ ] Participate in ask-me-anything, birds of a feather or expert-led panel discussions on these topics at LF and non-LF events
 - [ ] Advice on OSPOlogy and OSPOCon-branded programs by providing guidance on themes and formats, and speaking at sessions when possible
 - [ ] Connect with TODO Ambassadors and Working Group Chairs and provide them with resources and expert guidance to help them present their work at LF events.
 - [ ] Support release planning of TODO resources and presentation opportunities at events

--- a/goals.md
+++ b/goals.md
@@ -40,7 +40,7 @@ Maintain and improve TODO Group's GitHub repositories so information stays accur
 **The Steering Committee is committed to:** 
 
 - [ ] Provide TODO repo maintenance and cleanup so resources remain findable and trustworthy (landscape, guides, governance)
-- [ ] Ensure repos reflect current community decisions and aligns with open source management profession 
+- [ ] Ensure repos reflect current community decisions and align with open source management best practices 
 
 
 # 📌 2025

--- a/goals.md
+++ b/goals.md
@@ -35,7 +35,7 @@ Support TODO members and working groups in sharing guidance and reusable resourc
 
 ## Keep TODO resources current and easy to navigate
 
-Maintain and improve TODO GH's repositories so information stays accurate, up to date, and easy to find and reuse
+Maintain and improve TODO Group's GitHub repositories so information stays accurate, up to date, and easy to find and reuse
 
 **The Steering Committee is committed to:** 
 

--- a/goals.md
+++ b/goals.md
@@ -8,11 +8,11 @@ Based on the TODO Group’s [2025 end-of-year overview](https://todogroup.org/bl
 
 ## Grow and Sustain Leadership Roles
 
-Make it easier for people to step into—and succeed in—leadership through clear entry points and consistent support.
+Make it easier for people to step into and succeed in leadership through clear entry points and consistent support
 
 **The Steering Committee is committed to:**
 
-- [ ]Improve and maintain documentation for working groups, events framework, and major deliverables
+- [ ] Improve and maintain documentation for working groups, events framework, and major deliverables
 - [ ] Establish a regular cadence of virtual member all-hands calls throughout the year, featuring sessions led by Ambassadors and members, and facilitated by Steering Committee members and the Linux Foundation staff project manager
 - [ ] Launch a lightweight mentorship program that connects new and experienced OSPO practitioners
 

--- a/goals.md
+++ b/goals.md
@@ -12,7 +12,7 @@ Make it easier for people to step into and succeed in leadership through clear e
 
 **The Steering Committee is committed to:**
 
-- [ ] Improve and maintain documentation for working groups, events framework, and major deliverables
+- [ ] Improve and maintain documentation for working groups, events, and major deliverables
 - [ ] Establish a regular cadence of virtual member all-hands calls throughout the year, featuring sessions led by Ambassadors and members, and facilitated by Steering Committee members and the Linux Foundation staff project manager
 - [ ] Launch a lightweight mentorship program that connects new and experienced OSPO practitioners
 

--- a/goals.md
+++ b/goals.md
@@ -27,7 +27,7 @@ Support TODO members and working groups in sharing guidance and reusable resourc
 **The Steering Committee is committed to:**
 
 - [ ] Participate in ask-me-anything, birds of a feather or expert-led panel discussions on these topics at major LF events
-- [ ] Advice on OSPOlogy and OSPOCon-branded program by providing guidance on themes and formats, and speaking at sessions when possible
+- [ ] Advice on OSPOlogy and OSPOCon-branded programs by providing guidance on themes and formats, and speaking at sessions when possible
 - [ ] Connect with TODO Ambassadors and Working Group Chairs and provide them with resources and expert guidance to help them present on these cases
 - [ ] Support release planning of TODO resources and presentation opportunities at events
 - [ ] Coordinate with sister ecosystems (OpenSSF, OpenChain, InnerSource Commons, CURIOSS, CNCF, LF Europe, CHAOSS) and local OSPO communities to co-present and/or co-develop resources and ensure the TODO community stays connected to major conversations on AI, software supply chain security, and regulatory trends

--- a/goals.md
+++ b/goals.md
@@ -1,6 +1,47 @@
 # 🧩 TODO Strategic Goals
 
-Bellow is a set of yearly goals to the TODO Group for review and sign-off by the Steering Committee in order to let the TODO Group shape the program and execute. The goals will be revisited and updated yearly.
+Below are the Steering Committee’s recommended annual goals for the TODO Group Community. They are intended as guidance, and will be reviewed and updated each year
+
+# 📌 2026
+
+Based on the TODO Group’s [2025 end-of-year overview](https://todogroup.org/blog/end-of-year-2025/), the Steering Committee advises on the following strategic goals and commits to supporting the TODO community, including individual contributors, Ambassadors, and general member organizations, in advancing the practice of open source management within organizations through community-driven resources and shared learning
+
+## Grow and Sustain Leadership Roles
+
+Make it easier for people to step into—and succeed in—leadership through clear entry points and consistent support.
+
+**The Steering Committee is committed to:**
+
+- [ ]Improve and maintain documentation for working groups, events framework, and major deliverables
+- [ ] Establish a regular cadence of virtual member all-hands calls throughout the year, featuring sessions led by Ambassadors and members, and facilitated by Steering Committee members and the Linux Foundation staff project manager
+- [ ] Launch a lightweight mentorship program that connects new and experienced OSPO practitioners
+
+## Help OSPOs Strengthen Value Across Business Strategy, AI, and Security
+
+Support TODO members and working groups in sharing guidance and reusable resources on AI strategy and software supply chain security, going beyond open source policy. Examples of topics to cover include:
+
+- How organizations adopt and contribute to open source AI as part of their AI strategy
+- Use Cases that connect OSPOs with security, legal, and platform teams beyond open source policy
+- How OSPO practice at enterprises links to broader public-interest frameworks (e.g UN Open Source Goals, Academic Research, etc)
+
+**The Steering Committee is committed to:**
+
+- [ ] Participate in ask-me-anything, birds of a feather or expert-led panel discussions on these topics at major LF events
+- [ ] Advice on OSPOlogy and OSPOCon-branded program by providing guidance on themes and formats, and speaking at sessions when possible
+- [ ] Connect with TODO Ambassadors and Working Group Chairs and provide them with resources and expert guidance to help them present on these cases
+- [ ] Support release planning of TODO resources and presentation opportunities at events
+- [ ] Coordinate with sister ecosystems (OpenSSF, OpenChain, InnerSource Commons, CURIOSS, CNCF, LF Europe, CHAOSS) and local OSPO communities to co-present and/or co-develop resources and ensure the TODO community stays connected to major conversations on AI, software supply chain security, and regulatory trends
+
+
+## Keep TODO resources current and easy to navigate
+
+Maintain and improve TODO GH's repositories so information stays accurate, up to date, and easy to find and reuse
+
+**The Steering Committee is committed to:** 
+
+- [ ] Provide TODO repo maintenance and cleanup so resources remain findable and trustworthy (landscape, guides, governance)
+- [ ] Ensure repos reflect current community decisions and aligns with open source management profession 
+
 
 # 📌 2025
 


### PR DESCRIPTION
Updated the strategic goals for the TODO Group Community for 2026, including commitments from the Steering Committee.

[Watch Preview](https://github.com/todogroup/governance/blob/16df3962671e2e168c739345196c03698bb19dce/goals.md)

## Actions Needed

- [x] At least one Steering Committee member reviews the content and either requests changes or approves it
- [x] A majority of Steering Committee members vote in favor of the proposed 2026 goals (by reacting to the GitVote comment posted below)