### PR TITLE
Update Amazon members

### DIFF
--- a/structure/members/MEMBERS.csv
+++ b/structure/members/MEMBERS.csv
@@ -11,7 +11,7 @@ Ahmed Sobeh,ahmedsobeh,Aiven,,Active
 Kevin Webber,rocketpages,Aiven,,Active
 Jonas van den Bogaard,Jonasvdbo,Alliander,yes,Active
 Nico Rikken,nicorikken,Alliander,,Active
-Nithya Ruff,nruff,Amazon,yes,Active
+Stormy Peters,stormypeters,Amazon,yes,Active
 Nathalie C. Chan King Choy,nathalie-ckc,AMD,yes,Active
 Tomas Evensen,tomasevensen,AMD,,Active
 Jenny Thayer,jrburcio,Apple,,Active


### PR DESCRIPTION
Replacing #399.

Replacing Nithya with Stormy as Amazon's representative at TodoGroup.