### PR TITLE
Add liaison role in TODO Charter

### DIFF
--- a/CHARTER.adoc
+++ b/CHARTER.adoc
@@ -55,7 +55,7 @@ The TODO Group Steering Committee may appoint one or more Working Group Liaison(
 
 ... Responsibilities:
 .... Help WG chairs and participants understand how TODO works (e.g., where to find governance documents, how to propose changes, how to request support).
-.... Ensure a lightweight “WG essentials” overview exists and is kept up to date (purpose, leads, meeting cadence, links to notes, and deliverables).
+.... Ensure a lightweight WG CHARTER exists and is kept up to date (purpose, leads, meeting cadence, links to notes, and deliverables).
 .... Identify mission misalignments, recurring blockers, and duplication across WGs, and surface them to WG chairs, participants, and the Steering Committee.
 .... Promote an update mechanism beyond Slack to ensure WG progress and decisions are captured in a durable, accessible place (e.g., periodic written updates and links to notes/issues/PRs).
 

--- a/CHARTER.adoc
+++ b/CHARTER.adoc
@@ -1,5 +1,5 @@
-= Charter of General Members and Steering Committee
-*Disclaimer: Please note this charter covers the activities and responsibilities of general members and the steering committee. There are many other folks active in TODO Group, such as individuals employed by OSPO Associate Organizations and individuals who are OSPO practitioners and contributors to open source projects and communities. Individual persons are welcome and encouraged to join and participate in the TODO Group as long as they abide by our code of conduct. For information, please visit the [TODO Group community & network page](https://todogroup.org/community/)*
+= Charter of TODO Group
+
 :toc:
 
  . *Mission of the TODO Group (“TODO”).*
@@ -46,9 +46,31 @@ The TODO Group's general membership shall be composed of the General Members. An
  .. Any issues that the Steering Committee is unable to resolve shall be referred to The Linux Foundation for resolution.
  . *Officers*
 The Steering Committee shall elect a Chairperson and, if so desired, may elect such other officers as it may choose. All officers shall be elected annually. There are no limits on the number of terms an officer may serve.
- . *Voting*
+
+.. *Liaisons*
+The TODO Group Steering Committee may appoint one or more Working Group Liaison(s) (“Liaisons”) to support the effectiveness, transparency, and continuity of TODO Working Groups (WGs). A Liaison is a current Steering Committee member appointed to help Working Groups operate smoothly by connecting WG chairs and participants with information, resources, and processes available within the TODO Group and The Linux Foundation, and by helping ensure each WG’s mission aligns with TODO Group values.
+
+... Definition:
+.... A Liaison serves as a coordination point between the Steering Committee and one or more WGs, helping ensure clarity, continuity, and timely communication.
+
+... Responsibilities:
+.... Help WG chairs and participants understand how TODO works (e.g., where to find governance documents, how to propose changes, how to request support).
+.... Ensure a lightweight “WG essentials” overview exists and is kept up to date (purpose, leads, meeting cadence, links to notes, and deliverables).
+.... Identify mission misalignments, recurring blockers, and duplication across WGs, and surface them to WG chairs, participants, and the Steering Committee.
+.... Promote an update mechanism beyond Slack to ensure WG progress and decisions are captured in a durable, accessible place (e.g., periodic written updates and links to notes/issues/PRs).
+
+... Reporting:
+.... Liaisons should provide periodic updates to the Steering Committee, as needed or on a cadence agreed by the Steering Committee.
+
+... Term length:
+.... Liaisons are appointed by the Steering Committee.
+.... A Liaison’s term lasts until their Steering Committee term ends, unless reappointed or replaced earlier by the Steering Committee.
+
+
+
 Actions of the Steering Committee may be taken at in-person meetings, via conference call, or through electronic means, including email or real-time chat. In order for any action to be effective, it shall be approved by a simple majority of the Steering Committee members participating in person and/or by conference call, when a quorum is so present. Quorum shall be met when at least five (5) members of the Steering Committee are present. Any vote may be taken without a meeting electronically but shall require a majority of the entire Steering Committee to pass.
- . *Working Groups*
+
+. *Working Groups*
 The TODO Group will host Working Groups for everyone, including its general members to contribute to that are intended to accelerate its mission. Initial Working Groups are expected to cover topics including, but not limited to:
  * Well documented software to facilitate the management of open source software engagement and operations by an organization
  * Blog and wiki articles providing recommendations on how to manage open source operations and implement open source usage and contributions best practices by an organization


### PR DESCRIPTION
Create a formal Liaison role to support Working Groups (WGs). This addition should be reviewed and approved by the Steering Committee (SC) via GitVote.