### PR TITLE
Create draft for TODO Ambassador Manual + Current Needs doc

### DIFF
--- a/structure/ambassadors/ambassador-manual.md
+++ b/structure/ambassadors/ambassador-manual.md
@@ -1,8 +1,8 @@
-# DRAFT: TODO OSPO Ambassador Manual (2026 Edition)
+# DRAFT: TODO Group OSPO Ambassador Manual (2026 Edition)
 
 > Draft Version - July 5th, 2026
 
-TODO Group OSPO Ambassadors (TOAs) are experienced practitioners who help OSPO teams and open source managers and practitioners get started in this field, advance open source management and operations in their organizations **using TODO Group resources and best practices**. 
+TODO Group OSPO Ambassadors (shortened to *TODO Ambassadors*) are experienced practitioners who help OSPO teams and open source managers and practitioners get started in this field, advance open source management and operations in their organizations **using TODO Group resources and best practices**. 
 This document is the operating manual: what Ambassadors do, what counts as a contribution, how to submit it, and how contributions are tracked.
 
 Overall, we ask ambassadors to:
@@ -32,7 +32,7 @@ speaking about our working groups and resources, contributing to our repos and d
 
 ## What Ambassadors Do
 
-As a TODO OSPO Ambassador, you are expected to:
+As a TODO Ambassador, you are expected to:
 
 - Make at least one contribution per month
 
@@ -48,10 +48,8 @@ As a TODO OSPO Ambassador, you are expected to:
 
 ## Ways to Contribute
 
-Every contribution should connect to a real TODO initiative or resource and help someone understand, try, use, or contribute to it. Contributions fall into four buckets. Lead with whichever fits your strengths — you do not need to do all of
-them.
-
-> 💡 If you are sure where to start, see the [TODO Ambassador Current Needs](./current-needs.md) sheet for where we need the most help right now
+Every contribution should connect to a real TODO initiative or resource and help someone understand, try, use, or contribute to it. Contributions fall into four buckets. Lead with whichever fits your strengths, you do not need to do all of
+them!
 
 ### Advocate
 
@@ -121,7 +119,7 @@ A strong contribution does at least one of:
 
 - Explains a real problem practitioners have
 - Shows how a TODO resource helps; helps someone get started
-- teaches a concept clearly; shares lessons from real usage
+- Teaches a concept clearly; shares lessons from real usage
 - Makes it easier for someone else to contribute
 - Supports another community member
 - Improves a TODO initiative directly
@@ -138,36 +136,27 @@ Unless there's clear added value:
 - AI-generated content you haven't meaningfully reviewed, tested, or improved
 - Anything inaccurate, misleading, or harmful
 
-## TODO Group Points
+## Examples of contributions
 
-,
-You do not calculate your own points. You simply submit your work and we review the process, classify and score it.
-
-| Contribution | Points |
-| --- | --- |
-| Social thread / short educational post (references a TODO resource) | 5 |
-| Community question answered / support | 5 – 15 |
-| Onboarding or mentoring a newcomer | 10 |
-| Blog post (external blog or the TODO blog) | 20 |
-| Short Video | 20 |
-| Tutorial / Walkthrough | 25 |
-| Meetup talk | 25 |
-| Podcast guest | 25 |
-| Conference talk (that connects with a TODO working group or resource) | 30 |
-| Co-chairing or moderating a TODO working group call (per active month) | 30 |
-| Workshop | 35 |
-| Organizing or running an OSPOlogy chapter meetup | 40 |
-| PR, issue, deliverable contribution to a TODO repo or initiative | 5 - 50 |
-
-These are baselines. Final scoring may reflect quality, depth, relevance, and the evidence provided. Contributions may relate to more than one initiative.
+- Social thread / short educational post (references a TODO resource) 
+- Community question answered / support
+- Onboarding or mentoring a newcomer 
+- Blog post (external blog or the TODO blog)
+- Short Video
+- Tutorial / Walkthrough
+- Meetup talk 
+- Podcast guest
+- Conference talk (that connects with a TODO working group or resource) 
+- Co-chairing or moderating a TODO working group call (per active month) 
+- Workshop 
+- Organizing or running an OSPOlogy chapter meetup 
+- PR, issue, deliverable contribution to a TODO repo or initiative
 
 ## How to Submit a Contribution
 
-
 Ambassadors submit through the private TODO Ambassadors submissions repository (`todogroup/ambassadors`) using GitHub issues
 
-**Step 1: Open a submission issue.** Use the Ambassador Contribution Submission
-template
+**Step 1: Open a submission issue.** Use the Ambassador Contribution Submission template
 
 **Step 2: Fill in the few required fields:**
 
@@ -176,26 +165,20 @@ template
 - The related TODO initiative(s) or working group(s)
 
 
-**Step 3: Submit.** The system reviews the contribution, classifies it,
-checks relevance, recommends a score, and asks for anything missing. a 
-
+**Step 3: Submit.** The system reviews the contribution, classifies it, checks relevance and asks for anything missing.
 
 > Examples of good contribution URLs include: a blog post, GitHub PR or issue, YouTube video, a conference or meetup session page, slide deck, social thread, podcast episode, or a link to the working-group deliverable you worked
 on. For community help, include enough detail to review without exposing private information
 
+## Recognition and Contribution Opportunities
 
-## Recognition, Status, and Badges
+TODO Ambassadors may be recognized for their contributions and invited to participate in additional opportunities through:
 
-Approved contributions are recorded as scorecards. Scorecards generate the monthly reports, recognition roundups, and program analysis. You don't create scorecards yourself. The review process does.
-
-Active Ambassadors are recognized through:
-
-- The Ambassador leaderboard and monthly roundups
-- Recognition on the [TODO Ambassadors page](https://todogroup.org/community/ambassadors/)
-- A **TODO OSPO Ambassadors Credly badge** issued by the Linux Foundation
-- Amplification through TODO/OSPONews and community channels
-
-Status is meant to make participation visible and motivating, not to turn community work into a grind
+- Features in Ambassador monthly roundups shared with the community, Steering Committee, and TODO Group members
+- Amplification of their work through the TODO Group blog, OSPO Newsletter, and social channels
+- Invitations to selected Steering Committee meetings to share community perspectives
+- Opportunities to contribute reviews, quotes, or expertise to TODO-branded white papers and studies developed with the Linux Foundation
+- Consideration for event program committees and other relevant TODO Group initiatives
 
 ## Requirements, Benefits, and Renewal
 
@@ -216,21 +199,23 @@ Apply via the [TODO governance repo](https://github.com/todogroup/governance/iss
 
 ### Benefits
 
- Recognition across TODO Group and Linux Foundation social channels, and priority consideration for opportunities across the LF ecosystem.
+TODO OSPO Ambassadors receive:
 
-- Recognition for your expertise and contributions, including amplification across TODO Group and Linux Foundation social channels
-- Consideration for opportunities across the Linux Foundation ecosystem when they come up (forewords, report reviews, event program committees, and more)
-- A global network of fellow Ambassadors
-- TODO/LF platform support for events, speaking, content, and mentoring
-- Discount codes for LF-sponsored events
-- Exclusive swag and giveaways (when resources are available)
-- A TODO OSPO Ambassadors Credly badge from the Linux Foundation
+- An official profile on the TODO Ambassadors page
+- A TODO OSPO Ambassador Credly badge issued by the Linux Foundation
+- Access to a global network of fellow Ambassadors
+- TODO Group and Linux Foundation platform support for events and local meetups
+- Consideration for relevant opportunities across the Linux Foundation ecosystem
+- Discount codes for selected Linux Foundation events
+- Exclusive swag and giveaways, when available
 
-The TOA role is **NOT** a paid position
+This role is **NOT** a paid position
 
-### Commitment and renewal
+### Commitment and Renewal
 
 Ambassadorships run for two years. Ongoing participation is measured by your monthly contributions to our Steering Committe and reviewed mid-term, which may consider consistency, quality, project relevance, community impact, professionalism, responsiveness, and continued interest.
+
+Sustained inactivity or lack of response to program communications may result in an earlier review and, where appropriate, removal from the program.
 
 ## Code of Conduct
 
@@ -238,13 +223,7 @@ Ambassadors are visible members of the TODO community. Represent the program in 
 
 ## FAQ
 
-**Do I need to calculate my own points?**
-No. Submit the contribution; the review system will follow up and recommend a score.
-
-**Can I submit after the month ends?**
-Yes. Late submissions can count.
-
-**Does answering community questions count?**
+**Does answering community questions count as contributions?**
 Yes, when it's tied to a TODO initiative, and there's enough evidence to review. Remove private or sensitive details from any screenshots or summaries.
 
 **Do I have to organize a meetup?**

--- a/structure/ambassadors/ambassador-manual.md
+++ b/structure/ambassadors/ambassador-manual.md
@@ -158,14 +158,20 @@ Ambassadors submit through the private TODO Ambassadors submissions repository (
 
 **Step 1: Open a submission issue.** Use the Ambassador Contribution Submission template
 
-**Step 2: Fill in the few required fields:**
+**Step 2: Fill in the few required fields.**
 
 - Your GitHub handle
 - The contribution URL (see below)
 - The related TODO initiative(s) or working group(s)
 
 
-**Step 3: Submit.** The system reviews the contribution, classifies it, checks relevance and asks for anything missing.
+**Step 3: Submit.** 
+
+The system reviews the contribution, classifies it, checks relevance and asks for anything missing.
+
+**Step 4: Share.** 
+
+Once your PR is merged, share it in applicable TODO Slack channels and Social Media content
 
 > Examples of good contribution URLs include: a blog post, GitHub PR or issue, YouTube video, a conference or meetup session page, slide deck, social thread, podcast episode, or a link to the working-group deliverable you worked
 on. For community help, include enough detail to review without exposing private information

--- a/structure/ambassadors/ambassador-manual.md
+++ b/structure/ambassadors/ambassador-manual.md
@@ -12,7 +12,7 @@ Overall, we ask ambassadors to:
 - Support the TODO Group community
 
 
-> Where the [TODO Ambassadors page](https://todogroup.org/community/ambassadors/) page introduces the program, this manual explains how to participate
+> 💡 The [TODO Ambassadors page](https://todogroup.org/community/ambassadors/) page introduces the program. This manual explains how to participate
 
 
 ## About TODO
@@ -28,7 +28,7 @@ Ambassadors help more practitioners find, use, and contribute to that work
 The TODO Group OSPO Ambassador Program is a group of community leaders who advocate OSPO best practices and TODO initiatives globally, support and mentor newcomers, and help the TODO Group community grow.
 
 > 💡 The program historically centered on organizing local meetups and OSPOlogy chapters. That work still matters, but it is now one path among several. We are broadening the program so Ambassadors are encouraged and recognized for a wider contribution types to TODO Group initiatives: writing and
-speaking about our working groups and resources, contributing to our repos and deliverables, co-chairing working groups, and helping newcomers get started.
+speaking about our working groups and resources, contributing to our repos and deliverables, co-chairing working groups, and helping newcomers get started
 
 ## What Ambassadors Do
 
@@ -43,7 +43,7 @@ As a TODO OSPO Ambassador, you are expected to:
 - Bring community feedback back to TODO
 - Follow the [TODO Code of Conduct](https://todogroup.org/about/code-of-conduct/)
 
-> 💡 You are not expected to know everything. You are expected to be curious, honest, helpful, and grounded in what practitioners actually need.
+> 💡 You are not expected to know everything. You are expected to be curious, honest, helpful, and grounded in what practitioners actually need
 
 
 ## Ways to Contribute
@@ -67,7 +67,7 @@ Title examples:
 - Good: a talk introducing the OSS in Business working group's findings
 - Weak: a general open source talk that did not mention TODO Group efforts
   
-**Educational posts and threads** about OSPO and open source management that point directly to TODO resources (the Book, guides, glossary, MindMap,training, case studies)
+**Educational posts and threads** about OSPO and open source management that point directly to TODO resources (the Book, guides, glossary, MindMap, training, case studies)
 
 - Good: a thread walking through the OSPO MindMap with a link
 - Weak: OSPO comment with no reference to TODO's work
@@ -78,7 +78,7 @@ Title examples:
 
 ### Contribute
 
-Contributions that improve TODO's shared resources directly. TODO isn't a code-heavy project (our repos are docs, curated lists, and working-group resources) but several of them need real technical and open source management judgment to review what goes in.
+Contributions that improve TODO's shared resources directly. TODO isn't a code-heavy project (our repos are docs, curated lists, and working-group resources), but several of them need real technical and open source management judgment to review what goes in.
 
 - **Review and help maintain Awesome OSPO Tooling**
   ([`todogroup/awesome-ospo`](https://github.com/todogroup/awesome-ospo)).
@@ -159,7 +159,7 @@ You do not calculate your own points. You simply submit your work and we review 
 | Organizing or running an OSPOlogy chapter meetup | 40 |
 | PR, issue, deliverable contribution to a TODO repo or initiative | 5 - 50 |
 
-These are baselines. Final scoring may reflect quality, depth, relevance, and the evidence provided. Contributions may relate to more than one initiative; listing several helps our reporting but does not automatically increase points.
+These are baselines. Final scoring may reflect quality, depth, relevance, and the evidence provided. Contributions may relate to more than one initiative.
 
 ## How to Submit a Contribution
 
@@ -186,7 +186,7 @@ on. For community help, include enough detail to review without exposing private
 
 ## Recognition, Status, and Badges
 
-Approved contributions are recorded as scorecards. Scorecards generate the monthly reports, recognition roundups, and program analysis. You don't create scorecards yourself, the review process does.
+Approved contributions are recorded as scorecards. Scorecards generate the monthly reports, recognition roundups, and program analysis. You don't create scorecards yourself. The review process does.
 
 Active Ambassadors are recognized through:
 
@@ -195,8 +195,7 @@ Active Ambassadors are recognized through:
 - A **TODO OSPO Ambassadors Credly badge** issued by the Linux Foundation
 - Amplification through TODO/OSPONews and community channels
 
-Status is meant to make participation visible and motivating — not to turn
-community work into a grind.
+Status is meant to make participation visible and motivating, not to turn community work into a grind
 
 ## Requirements, Benefits, and Renewal
 
@@ -213,8 +212,7 @@ community work into a grind.
   chair/co-chair in a TODO working group with 1+ year of experience organizing
   events, speaking, mentoring, or creating content.
 
-Apply via the
-[TODO governance repo](https://github.com/todogroup/governance/issues/new/choose).
+Apply via the [TODO governance repo](https://github.com/todogroup/governance/issues/new/choose).
 
 ### Benefits
 
@@ -244,10 +242,10 @@ Ambassadors are visible members of the TODO community. Represent the program in 
 No. Submit the contribution; the review system will follow up and recommend a score.
 
 **Can I submit after the month ends?**
-Yes. Late submissions can count toward annual totals.
+Yes. Late submissions can count.
 
 **Does answering community questions count?**
-Yes, when it's tied to a TODO initiative and there's enough evidence to review. Remove private or sensitive details from any screenshots or summaries.
+Yes, when it's tied to a TODO initiative, and there's enough evidence to review. Remove private or sensitive details from any screenshots or summaries.
 
 **Do I have to organize a meetup?**
 No. Meetups are one path. Blogging, speaking, contributing to repos and deliverables, co-chairing a working group, and supporting the community all

--- a/structure/ambassadors/ambassador-manual.md
+++ b/structure/ambassadors/ambassador-manual.md
@@ -51,7 +51,7 @@ As a TODO OSPO Ambassador, you are expected to:
 Every contribution should connect to a real TODO initiative or resource and help someone understand, try, use, or contribute to it. Contributions fall into four buckets. Lead with whichever fits your strengths — you do not need to do all of
 them.
 
-> 💡 If you are sure where to start, see the **[TODO Ambassador Current Needs](./TODO-Ambassador-current-needs.md) sheet for where we need the most help right now
+> 💡 If you are sure where to start, see the [TODO Ambassador Current Needs](./current-needs.md) sheet for where we need the most help right now
 
 ### Advocate
 

--- a/structure/ambassadors/ambassador-manual.md
+++ b/structure/ambassadors/ambassador-manual.md
@@ -1,0 +1,267 @@
+# DRAFT: TODO OSPO Ambassador Manual (2026 Edition)
+
+> Draft Version - July 5th, 2026
+
+TODO Group OSPO Ambassadors (TOAs) are experienced practitioners who help OSPO teams and open source managers and practitioners get started in this field, advance open source management and operations in their organizations **using TODO Group resources and best practices**. 
+This document is the operating manual: what Ambassadors do, what counts as a contribution, how to submit it, and how contributions are tracked.
+
+Overall, we ask ambassadors to:
+
+- Do real work in TODO initiatives
+- Advocate for OSPO best practices showcasing TODO community resources
+- Support the TODO Group community
+
+
+> Where the [TODO Ambassadors page](https://todogroup.org/community/ambassadors/) page introduces the program, this manual explains how to participate
+
+
+## About TODO
+
+The [TODO Group](https://todogroup.org/) is an open community of practitioners building and running Open Source Program Offices (OSPOs) and sharing best practices on open source management. Hosted by the Linux Foundation, TODO produces shared, vendor-neutral resources (the OSPO Book,
+guides, the OSPO Landscape, training, case studies, and other working-group deliverables) that help organizations effectively manage open source operations in their organizations
+
+Ambassadors help more practitioners find, use, and contribute to that work
+
+
+## About the Ambassador Program
+
+The TODO Group OSPO Ambassador Program is a group of community leaders who advocate OSPO best practices and TODO initiatives globally, support and mentor newcomers, and help the TODO Group community grow.
+
+> 💡 The program historically centered on organizing local meetups and OSPOlogy chapters. That work still matters, but it is now one path among several. We are broadening the program so Ambassadors are encouraged and recognized for a wider contribution types to TODO Group initiatives: writing and
+speaking about our working groups and resources, contributing to our repos and deliverables, co-chairing working groups, and helping newcomers get started.
+
+## What Ambassadors Do
+
+As a TODO OSPO Ambassador, you are expected to:
+
+- Make at least one contribution per month
+
+    - (A helpful answer in the community Slack, mentoring a working group meeting, a blog post referencing TODO resources, a talk in an OSPOlogy event, a merged PR, all count)
+      
+- Advocate OSPO best practices and TODO initiatives accurately and helpfully
+- Represent TODO professionally, inclusively, and in line with TODO Group mission
+- Bring community feedback back to TODO
+- Follow the [TODO Code of Conduct](https://todogroup.org/about/code-of-conduct/)
+
+> 💡 You are not expected to know everything. You are expected to be curious, honest, helpful, and grounded in what practitioners actually need.
+
+
+## Ways to Contribute
+
+Every contribution should connect to a real TODO initiative or resource and help someone understand, try, use, or contribute to it. Contributions fall into four buckets. Lead with whichever fits your strengths — you do not need to do all of
+them.
+
+> 💡 If you are sure where to start, see the **[TODO Ambassador Current Needs](./TODO-Ambassador-current-needs.md) sheet for where we need the most help right now
+
+### Advocate
+
+Help more practitioners understand OSPOs and TODO's work.
+
+**Blog posts** on either your own channel or the [TODO blog](https://todogroup.org/blog/)
+
+Title examples:
+- Good: "How we used the OSPO Book to structure our first program."
+- Weak: generic "why open source matters" post with no link to a TODO resource
+
+**Conference and meetup talks** about a TODO working group or community resource
+- Good: a talk introducing the OSS in Business working group's findings
+- Weak: a general open source talk that did not mention TODO Group efforts
+  
+**Educational posts and threads** about OSPO and open source management that point directly to TODO resources (the Book, guides, glossary, MindMap,training, case studies)
+
+- Good: a thread walking through the OSPO MindMap with a link
+- Weak: OSPO comment with no reference to TODO's work
+  
+**Short videos, podcast appearances, livestreams** that teach or demonstrate a TODO resource, event or working group
+
+**Bridge with adjacent communities** content or talks that connect TODO's work with neighboring efforts (OpenChain, CHAOSS, OpenSSF, CNCF, and others), helping practitioners see how the pieces of the open source ecosystem fit together
+
+### Contribute
+
+Contributions that improve TODO's shared resources directly. TODO isn't a code-heavy project (our repos are docs, curated lists, and working-group resources) but several of them need real technical and open source management judgment to review what goes in.
+
+- **Review and help maintain Awesome OSPO Tooling**
+  ([`todogroup/awesome-ospo`](https://github.com/todogroup/awesome-ospo)).
+  Provide technical oversight of the tools proposed for the list (assessing
+  maturity, licensing, section fit, and whether a submission holds up). This is one of
+  our clearest needs for Ambassadors with hands-on technical experience.
+- **Submit or review Pull requests and issues** in TODO repos, for example
+  [`todogroup/todogroup.org`](https://github.com/todogroup/todogroup.org) (the
+  website) and [`todogroup/ospology`](https://github.com/todogroup/ospology).
+  Regular, useful PRs and well-scoped issues both count.
+- **Working-group deliverables** such as writing, editing, research, or review for the
+  TODO Working Groups
+- **Initiative contributions** such as new TODO Group guides, OSPO glossary, translations, or case studies
+
+### Lead
+
+Help steer the work:
+
+- **Moderate or co-chair an official TODO working group.** This is recurring,
+  high-value work, and it is recognized as a first-class contribution (not the
+  title, but the ongoing act of running the group: agendas, facilitation,
+  keeping deliverables moving)
+- **Organize or run an OSPOlogy chapter or local meetup.** 
+
+### Support
+
+Help other people succeed.
+
+- **Answer community questions** in Slack, GitHub Discussions, or
+  OSPOlogy meetings, and follow up until the person is unblocked
+- **Help onboard newcomers.** Mentor someone new to OSPOs or to TODO Group community, or improve
+  the [Get Started](https://todogroup.org/community/get-started/) path so the
+  next person has an easier time
+
+## What Makes a Strong Contribution
+
+Strong contributions are specific and useful. *"OSPOs are important"* is not a contribution. *"Here is how I used this TODO Guide to justify an OSPO to my leadership"* is.
+
+A strong contribution does at least one of: 
+
+- Explains a real problem practitioners have
+- Shows how a TODO resource helps; helps someone get started
+- teaches a concept clearly; shares lessons from real usage
+- Makes it easier for someone else to contribute
+- Supports another community member
+- Improves a TODO initiative directly
+
+## What Usually Does Not Qualify
+
+Unless there's clear added value:
+
+- Generic OSPO or open source management content that doesn't reference a specific TODO
+  resource or community initiative
+- Reposts or shares without original comment
+- Promotional posts with no educational substance
+- Private conversations with no reviewable evidence
+- AI-generated content you haven't meaningfully reviewed, tested, or improved
+- Anything inaccurate, misleading, or harmful
+
+## TODO Group Points
+
+,
+You do not calculate your own points. You simply submit your work and we review the process, classify and score it.
+
+| Contribution | Points |
+| --- | --- |
+| Social thread / short educational post (references a TODO resource) | 5 |
+| Community question answered / support | 5 – 15 |
+| Onboarding or mentoring a newcomer | 10 |
+| Blog post (external blog or the TODO blog) | 20 |
+| Short Video | 20 |
+| Tutorial / Walkthrough | 25 |
+| Meetup talk | 25 |
+| Podcast guest | 25 |
+| Conference talk (that connects with a TODO working group or resource) | 30 |
+| Co-chairing or moderating a TODO working group call (per active month) | 30 |
+| Workshop | 35 |
+| Organizing or running an OSPOlogy chapter meetup | 40 |
+| PR, issue, deliverable contribution to a TODO repo or initiative | 5 - 50 |
+
+These are baselines. Final scoring may reflect quality, depth, relevance, and the evidence provided. Contributions may relate to more than one initiative; listing several helps our reporting but does not automatically increase points.
+
+## How to Submit a Contribution
+
+
+Ambassadors submit through the private TODO Ambassadors submissions repository (`todogroup/ambassadors`) using GitHub issues
+
+**Step 1: Open a submission issue.** Use the Ambassador Contribution Submission
+template
+
+**Step 2: Fill in the few required fields:**
+
+- Your GitHub handle
+- The contribution URL (see below)
+- The related TODO initiative(s) or working group(s)
+
+
+**Step 3: Submit.** The system reviews the contribution, classifies it,
+checks relevance, recommends a score, and asks for anything missing. a 
+
+
+> Examples of good contribution URLs include: a blog post, GitHub PR or issue, YouTube video, a conference or meetup session page, slide deck, social thread, podcast episode, or a link to the working-group deliverable you worked
+on. For community help, include enough detail to review without exposing private information
+
+
+## Recognition, Status, and Badges
+
+Approved contributions are recorded as scorecards. Scorecards generate the monthly reports, recognition roundups, and program analysis. You don't create scorecards yourself, the review process does.
+
+Active Ambassadors are recognized through:
+
+- The Ambassador leaderboard and monthly roundups
+- Recognition on the [TODO Ambassadors page](https://todogroup.org/community/ambassadors/)
+- A **TODO OSPO Ambassadors Credly badge** issued by the Linux Foundation
+- Amplification through TODO/OSPONews and community channels
+
+Status is meant to make participation visible and motivating — not to turn
+community work into a grind.
+
+## Requirements, Benefits, and Renewal
+
+### Requirements to join
+
+- Be 18 or older.
+- Follow the [TODO Code of Conduct](https://todogroup.org/about/code-of-conduct/).
+- Comply with the
+  [LF antitrust policy](https://www.linuxfoundation.org/legal/antitrust-policy).
+- Meet **at least one** of: an active contributor to a TODO initiative (Awesome
+  OSPO Tooling, OSPO Landscape, TODO blog/website, working-group deliverables,
+  etc.); a representative of a TODO General Member organization; an OSPOlogy
+  Program Committee member or organizer; or an active
+  chair/co-chair in a TODO working group with 1+ year of experience organizing
+  events, speaking, mentoring, or creating content.
+
+Apply via the
+[TODO governance repo](https://github.com/todogroup/governance/issues/new/choose).
+
+### Benefits
+
+ Recognition across TODO Group and Linux Foundation social channels, and priority consideration for opportunities across the LF ecosystem.
+
+- Recognition for your expertise and contributions, including amplification across TODO Group and Linux Foundation social channels
+- Consideration for opportunities across the Linux Foundation ecosystem when they come up (forewords, report reviews, event program committees, and more)
+- A global network of fellow Ambassadors
+- TODO/LF platform support for events, speaking, content, and mentoring
+- Discount codes for LF-sponsored events
+- Exclusive swag and giveaways (when resources are available)
+- A TODO OSPO Ambassadors Credly badge from the Linux Foundation
+
+The TOA role is **NOT** a paid position
+
+### Commitment and renewal
+
+Ambassadorships run for two years. Ongoing participation is measured by your monthly contributions to our Steering Committe and reviewed mid-term, which may consider consistency, quality, project relevance, community impact, professionalism, responsiveness, and continued interest.
+
+## Code of Conduct
+
+Ambassadors are visible members of the TODO community. Represent the program in a way that is respectful, inclusive, technically honest, helpful, supportive of maintainers, open to feedback, and clear about uncertainty. [TODO Code of Conduct](https://todogroup.org/about/code-of-conduct/).
+
+## FAQ
+
+**Do I need to calculate my own points?**
+No. Submit the contribution; the review system will follow up and recommend a score.
+
+**Can I submit after the month ends?**
+Yes. Late submissions can count toward annual totals.
+
+**Does answering community questions count?**
+Yes, when it's tied to a TODO initiative and there's enough evidence to review. Remove private or sensitive details from any screenshots or summaries.
+
+**Do I have to organize a meetup?**
+No. Meetups are one path. Blogging, speaking, contributing to repos and deliverables, co-chairing a working group, and supporting the community all
+count.
+
+**Can I use AI to create my contribution?**
+Yes, but you own the final quality, accuracy, and usefulness
+
+**What if I'm not sure something qualifies?**
+Submit it with notes explaining the practitioner value and the TODO connection, or ask in the Ambassador channel
+
+
+## Contact and Changes
+
+TODO Group Ambassador private Slack channel or <steering-committee@todogroup.org>
+
+> This program is adapted from the CNCF Ambassador Program, version 2.0, and AAIF Ambassador guidelines. To change this manual or the program, open a PR against [`todogroup/governance`](https://github.com/todogroup/governance/blob/main/TODO-OSPO-Ambassador-Program.md)

--- a/structure/ambassadors/current-needs.md
+++ b/structure/ambassadors/current-needs.md
@@ -1,0 +1,58 @@
+# TODO OSPO Ambassador Current Needs Guide
+
+## Where we need your help right now as an Ambassador
+
+These are the roles where TODO most needs Ambassador energy today. Pick the one that fits you (you don't have to do all of them). Each maps to the points model in the [TODO OSPO Ambassador Manual](./TODO-OSPO-Ambassador-manual.md).
+
+### 1. Awesome OSPO Tooling: Maintainer & Technical Reviewer
+
+- **The need:** Active maintainers to provide technical oversight of the tools being added to our curated tooling list
+
+- **What you'd do:** Review incoming tool submissions for maturity, licensing, and fit; keep the list accurate and current; help first-time contributors understand what a good submission looks like
+
+- **Great fit if:** you have hands-on technical and open source experience and can judge whether a tool holds up
+
+- **Where:** [`todogroup/awesome-ospo`](https://github.com/todogroup/awesome-ospo)
+
+- **Counts as:** project contribution/review (5 – 50 pts)
+
+### 2. Working-group co-chair: OSS in Business and Agentic AI to empower OSPOs
+
+- **The need:** Co-chairs with open source management experience to run our regular working-group calls and turn discussion into shipped work
+
+- **What you'd do:** Run the regular calls, set agendas and facilitate, and file PRs and issues that capture what each meeting decided or learned so the group's deliverables actually move between calls
+
+- **Great fit if:** you've run an OSPO or managed open source operations in an organization and can keep a group focused
+
+- **Where:** OSS in Business WG and/or Agentic AI to empower OSPOs WG
+
+- **Counts as:** WG co-chair 25 pts / active month, plus the PRs and issues you file
+
+### 3. Storyteller: Blogs and Videos on applying TODO resources in the real world
+
+- **The need:** More content showing how to use TODO resources to advance an organization's open source and AI strategy in organizations, and how TODO connects to the wider LF ecosystem
+
+- **What you'd do:** Write posts or record videos that apply TODO resources and best practices inside real companies, and bridge TODO's work with adjacent
+communities — OpenChain, CHAOSS, OpenSSF, CNCF, and others.
+
+- **Great fit if:** you like teaching and have a real story of putting OSPO practice to work
+
+- **Where:** external blog/video channel or the [TODO blog](https://todogroup.org/blog/)
+
+- **Counts as:** blog post (20 pts) video (20 pts) conference talk (30 pts)
+
+
+### 4. Project & community manager: keep the community and repos healthy
+
+- **The need:** People to keep TODO's community spaces and repositories in good shape
+
+- **What you'd do:** Help run and moderate the TODO Slack, welcome and route newcomers, and clean up and maintain TODO repos and resources (triage, housekeeping, and keeping things current)
+
+- **Great fit if:** you're organized, responsive, and enjoy tending a community
+
+- **Where:** TODO Slack and/or TODO repos
+
+- **Counts as:** community help (5 - 15 pts), onboarding (10 pts), PRs/issues (5 - 50 pts)
+
+
+> This is a living sheet. Our needs change. Last reviewed: July 2026

--- a/structure/ambassadors/current-needs.md
+++ b/structure/ambassadors/current-needs.md
@@ -2,7 +2,7 @@
 
 ## Where we need your help right now as an Ambassador
 
-These are the roles where TODO most needs Ambassador energy today. Pick the one that fits you (you don't have to do all of them). Each maps to the points model in the [TODO OSPO Ambassador Manual](./TODO-OSPO-Ambassador-manual.md).
+These are the roles where TODO most needs Ambassador energy today. Pick the one that fits you (you don't have to do all of them). Each maps to the points model in the [TODO OSPO Ambassador Manual](./Ambassador-manual.md).
 
 ### 1. Awesome OSPO Tooling: Maintainer & Technical Reviewer
 

--- a/structure/ambassadors/current-needs.md
+++ b/structure/ambassadors/current-needs.md
@@ -2,7 +2,7 @@
 
 ## Where we need your help right now as an Ambassador
 
-These are the roles where TODO most needs Ambassador energy today. Pick the one that fits you (you don't have to do all of them). Each maps to the points model in the [TODO OSPO Ambassador Manual](./Ambassador-manual.md).
+These are the roles where TODO most needs Ambassador energy today. Pick the one that fits you (you don't have to do all of them). Each maps to the points model in the [TODO OSPO Ambassador Manual](./ambassador-manual.md).
 
 ### 1. Awesome OSPO Tooling: Maintainer & Technical Reviewer
 


### PR DESCRIPTION
Added a draft version of the TODO OSPO Ambassador Manual for 2026 (followed by a current needs dos). The doc outlines the roles, contributions and makes clear guidelines and expectations  for OSPO Ambassadors

DRAFT ONLY. Steering Committee needs to review and approve